### PR TITLE
feat: TSK-31 implement AuthenticationServletFilter to validate cookies

### DIFF
--- a/boot/src/main/java/com/zextras/carbonio/tasks/JettyServer.java
+++ b/boot/src/main/java/com/zextras/carbonio/tasks/JettyServer.java
@@ -7,8 +7,11 @@ package com.zextras.carbonio.tasks;
 import com.google.inject.Inject;
 import com.zextras.carbonio.tasks.Constants.Service;
 import com.zextras.carbonio.tasks.Constants.Service.API.Endpoints;
+import com.zextras.carbonio.tasks.auth.AuthenticationServletFilter;
 import com.zextras.carbonio.tasks.graphql.GraphQLServlet;
 import com.zextras.carbonio.tasks.rest.RestApplication;
+import java.util.EnumSet;
+import javax.servlet.DispatcherType;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
@@ -74,6 +77,8 @@ public class JettyServer {
     ServletHolder graphQLServletHolder = new ServletHolder("graphql-servlet", graphQLServlet);
 
     servletContextHandler.addServlet(graphQLServletHolder, "/");
+    servletContextHandler.addFilter(
+        AuthenticationServletFilter.class, "/", EnumSet.of(DispatcherType.REQUEST));
     return servletContextHandler;
   }
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -130,6 +130,12 @@ SPDX-License-Identifier: AGPL-3.0-only
       <scope>test</scope>
     </dependency>
 
+    <!-- Authentication -->
+    <dependency>
+      <groupId>com.zextras.carbonio.user-management</groupId>
+      <artifactId>carbonio-user-management-sdk</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.mock-server</groupId>
       <artifactId>mockserver-netty-no-dependencies</artifactId>
@@ -342,6 +348,14 @@ SPDX-License-Identifier: AGPL-3.0-only
       <properties>
         <skip.integration.tests>false</skip.integration.tests>
         <skip.unit.tests>true</skip.unit.tests>
+      </properties>
+    </profile>
+    <profile>
+      <id>run-all-tests</id>
+      <properties>
+        <skip.integration.tests>false</skip.integration.tests>
+        <skip.unit.tests>false</skip.unit.tests>
+        <skip.jacoco.full.report.generation>false</skip.jacoco.full.report.generation>
       </properties>
     </profile>
     <profile>

--- a/core/src/main/java/com/zextras/carbonio/tasks/Constants.java
+++ b/core/src/main/java/com/zextras/carbonio/tasks/Constants.java
@@ -18,7 +18,6 @@ public final class Constants {
     private Service() {}
 
     public static final class API {
-      private API() {}
 
       public static final class Endpoints {
         public static final String GRAPHQL = "/graphql";
@@ -26,10 +25,14 @@ public final class Constants {
 
         private Endpoints() {}
       }
+
+      private API() {}
     }
   }
 
   public static final class Config {
+
+    public static final String ACCEPTED_COOKIE_TYPE = "ZM_AUTH_TOKEN";
 
     public static final class Properties {
       public static final String DATABASE_URL = "carbonio.tasks.db.url";
@@ -46,6 +49,15 @@ public final class Constants {
       public static final String USERNAME = "carbonio-tasks-db";
 
       private Database() {}
+    }
+
+    public static final class UserService {
+
+      public static final String PROTOCOL = "http";
+      public static final String URL = "127.78.0.16";
+      public static final int PORT = 20001;
+
+      private UserService() {}
     }
 
     private Config() {}
@@ -106,6 +118,13 @@ public final class Constants {
   }
 
   public static final class GraphQL {
+
+    public static final class Context {
+
+      public static final String REQUESTER_ID = "requesterId";
+
+      private Context() {}
+    }
 
     public static final class Types {
 

--- a/core/src/main/java/com/zextras/carbonio/tasks/auth/AuthenticationServletFilter.java
+++ b/core/src/main/java/com/zextras/carbonio/tasks/auth/AuthenticationServletFilter.java
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.tasks.auth;
+
+import com.zextras.carbonio.tasks.Constants.Config;
+import com.zextras.carbonio.tasks.Constants.Config.UserService;
+import com.zextras.carbonio.tasks.Constants.GraphQL.Context;
+import com.zextras.carbonio.usermanagement.UserManagementClient;
+import com.zextras.carbonio.usermanagement.entities.UserId;
+import io.vavr.control.Try;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Optional;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.http.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AuthenticationServletFilter implements Filter {
+
+  private static final Logger logger = LoggerFactory.getLogger(AuthenticationServletFilter.class);
+
+  @Override
+  public void init(FilterConfig filterConfig) throws ServletException {
+    Filter.super.init(filterConfig);
+    logger.info(
+        String.format(
+            "Filter initialized to %s endpoint",
+            filterConfig.getServletContext().getServletContextName()));
+  }
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+
+    if (request instanceof HttpServletRequest && response instanceof HttpServletResponse) {
+      HttpServletRequest httpRequest = (HttpServletRequest) request;
+      HttpServletResponse httpResponse = (HttpServletResponse) response;
+
+      Optional<Cookie> optZmCookie =
+          Arrays.stream(httpRequest.getCookies())
+              .filter(cookie -> Config.ACCEPTED_COOKIE_TYPE.equals(cookie.getName()))
+              .findFirst();
+
+      if (optZmCookie.isEmpty()) {
+        logger.error("The request is unauthorized: the cookie is missing");
+        httpResponse.setStatus(HttpStatus.SC_UNAUTHORIZED);
+        return;
+      }
+
+      // Unfortunately doFilter throws an exception, using the .map would lead to an unreadable code
+      Try<UserId> tryUserId =
+          UserManagementClient.atURL(UserService.PROTOCOL, UserService.URL, UserService.PORT)
+              .validateUserToken(optZmCookie.get().getValue());
+
+      if (tryUserId.isSuccess()) {
+        httpRequest.setAttribute(Context.REQUESTER_ID, tryUserId.get().getUserId());
+        filterChain.doFilter(httpRequest, httpResponse);
+      } else {
+        logger.error("The request is unauthorized: the cookie is invalid");
+        httpResponse.setStatus(HttpStatus.SC_UNAUTHORIZED);
+      }
+    } else {
+      logger.error("Unable to authenticate non HTTP requests");
+    }
+  }
+
+  @Override
+  public void destroy() {}
+}

--- a/core/src/main/java/com/zextras/carbonio/tasks/graphql/GraphQLProvider.java
+++ b/core/src/main/java/com/zextras/carbonio/tasks/graphql/GraphQLProvider.java
@@ -16,8 +16,10 @@ import com.zextras.carbonio.tasks.dal.dao.Status;
 import com.zextras.carbonio.tasks.graphql.datafetchers.DateTimeScalar;
 import com.zextras.carbonio.tasks.graphql.datafetchers.ServiceInfoDataFetcher;
 import com.zextras.carbonio.tasks.graphql.datafetchers.TaskDataFetchers;
+import com.zextras.carbonio.tasks.graphql.instrumentations.ContextInstrumentation;
 import com.zextras.carbonio.tasks.graphql.validators.InputFieldsValidator;
 import graphql.execution.ResultPath;
+import graphql.execution.instrumentation.SimpleInstrumentation;
 import graphql.execution.instrumentation.fieldvalidation.FieldValidation;
 import graphql.execution.instrumentation.fieldvalidation.FieldValidationInstrumentation;
 import graphql.execution.instrumentation.fieldvalidation.SimpleFieldValidation;
@@ -46,15 +48,19 @@ public class GraphQLProvider {
 
   private static final String schemaURL = "/api/schema.graphql";
 
+  private final ContextInstrumentation contextInstrumentation;
   private final ServiceInfoDataFetcher serviceInfoDataFetcher;
   private final TaskDataFetchers taskDataFetchers;
   private final InputFieldsValidator inputFieldsValidator;
 
   @Inject
   public GraphQLProvider(
+      ContextInstrumentation contextInstrumentation,
       ServiceInfoDataFetcher serviceInfoDataFetcher,
       TaskDataFetchers taskDataFetchers,
       InputFieldsValidator inputFieldsValidator) {
+
+    this.contextInstrumentation = contextInstrumentation;
     this.serviceInfoDataFetcher = serviceInfoDataFetcher;
     this.taskDataFetchers = taskDataFetchers;
     this.inputFieldsValidator = inputFieldsValidator;
@@ -72,6 +78,10 @@ public class GraphQLProvider {
                 inputFieldsValidator.createTaskValidator());
 
     return new FieldValidationInstrumentation(fieldValidation);
+  }
+
+  public SimpleInstrumentation getContextInstrumentation() {
+    return contextInstrumentation;
   }
 
   /**

--- a/core/src/main/java/com/zextras/carbonio/tasks/graphql/GraphQLServlet.java
+++ b/core/src/main/java/com/zextras/carbonio/tasks/graphql/GraphQLServlet.java
@@ -8,6 +8,7 @@ import com.google.inject.Inject;
 import graphql.kickstart.execution.GraphQLQueryInvoker;
 import graphql.kickstart.servlet.GraphQLConfiguration;
 import graphql.kickstart.servlet.GraphQLHttpServlet;
+import java.util.Arrays;
 
 /**
  * Represents a {@link javax.servlet.http.HttpServlet} for the GraphQL endpoint with a configuration
@@ -37,7 +38,10 @@ public class GraphQLServlet extends GraphQLHttpServlet {
   protected GraphQLConfiguration getConfiguration() {
     GraphQLQueryInvoker queryInvoker =
         GraphQLQueryInvoker.newBuilder()
-            .withInstrumentation(graphQLProvider.buildValidationInstrumentation())
+            .with(
+                Arrays.asList(
+                    graphQLProvider.buildValidationInstrumentation(),
+                    graphQLProvider.getContextInstrumentation()))
             .build();
 
     return GraphQLConfiguration.with(graphQLProvider.buildSchema()).with(queryInvoker).build();

--- a/core/src/main/java/com/zextras/carbonio/tasks/graphql/datafetchers/TaskDataFetchers.java
+++ b/core/src/main/java/com/zextras/carbonio/tasks/graphql/datafetchers/TaskDataFetchers.java
@@ -7,6 +7,7 @@ package com.zextras.carbonio.tasks.graphql.datafetchers;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.zextras.carbonio.tasks.Constants.GraphQL;
+import com.zextras.carbonio.tasks.Constants.GraphQL.Context;
 import com.zextras.carbonio.tasks.Constants.GraphQL.Inputs;
 import com.zextras.carbonio.tasks.Constants.GraphQL.Inputs.NewTaskInput;
 import com.zextras.carbonio.tasks.dal.dao.Priority;
@@ -36,8 +37,7 @@ public class TaskDataFetchers {
     return environment ->
         CompletableFuture.supplyAsync(
             () -> {
-              String userId = "00000000-0000-0000-0000-000000000000";
-
+              String userId = environment.getGraphQlContext().get(Context.REQUESTER_ID);
               Map<String, Object> newTask = environment.getArgument("newTask");
 
               Long reminderAt = (Long) newTask.get(NewTaskInput.REMINDER_AT);
@@ -77,7 +77,7 @@ public class TaskDataFetchers {
     return environment ->
         CompletableFuture.supplyAsync(
             () -> {
-              String userId = "00000000-0000-0000-0000-000000000000";
+              String userId = environment.getGraphQlContext().get(Context.REQUESTER_ID);
               UUID taskId = UUID.fromString(environment.getArgument(Inputs.TASK_ID));
               return taskRepository
                   .getTask(taskId, userId)
@@ -100,7 +100,7 @@ public class TaskDataFetchers {
     return environment ->
         CompletableFuture.supplyAsync(
             () -> {
-              String userId = "00000000-0000-0000-0000-000000000000";
+              String userId = environment.getGraphQlContext().get(Context.REQUESTER_ID);
               Priority priority = environment.getArgument(Inputs.PRIORITY);
               Status status = environment.getArgument(Inputs.STATUS);
 

--- a/core/src/main/java/com/zextras/carbonio/tasks/graphql/instrumentations/ContextInstrumentation.java
+++ b/core/src/main/java/com/zextras/carbonio/tasks/graphql/instrumentations/ContextInstrumentation.java
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.tasks.graphql.instrumentations;
+
+import com.zextras.carbonio.tasks.Constants.GraphQL.Context;
+import graphql.ExecutionResult;
+import graphql.execution.instrumentation.InstrumentationContext;
+import graphql.execution.instrumentation.SimpleInstrumentation;
+import graphql.execution.instrumentation.SimpleInstrumentationContext;
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
+import java.util.NoSuchElementException;
+import javax.servlet.http.HttpServletRequest;
+
+public class ContextInstrumentation extends SimpleInstrumentation {
+
+  @Override
+  public InstrumentationContext<ExecutionResult> beginExecution(
+      InstrumentationExecutionParameters parameters) {
+    HttpServletRequest request = parameters.getGraphQLContext().get(HttpServletRequest.class);
+
+    if (request != null) {
+      String requesterId = (String) request.getAttribute(Context.REQUESTER_ID);
+
+      if (requesterId != null) {
+        parameters.getGraphQLContext().put(Context.REQUESTER_ID, requesterId);
+        return SimpleInstrumentationContext.noOp();
+      }
+      throw new NoSuchElementException("Unable to find the requestId attribute in the request");
+    }
+
+    throw new NoSuchElementException("Unable to find an HttpServletRequest object in the context");
+  }
+}

--- a/core/src/test/java-it/com/zextras/carbonio/tasks/graphql/CreateTaskApiIT.java
+++ b/core/src/test/java-it/com/zextras/carbonio/tasks/graphql/CreateTaskApiIT.java
@@ -18,6 +18,7 @@ import org.eclipse.jetty.server.LocalConnector;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 
 public class CreateTaskApiIT {
 
@@ -44,6 +45,10 @@ public class CreateTaskApiIT {
             .init()
             .withDatabase()
             .withServiceDiscover()
+            .withUserManagement(
+                ImmutableMap.<String, String>builder()
+                    .put("fake-user-cookie", "00000000-0000-0000-0000-000000000000")
+                    .build())
             .withGraphQlServlet()
             .build()
             .start();
@@ -60,9 +65,10 @@ public class CreateTaskApiIT {
   public void givenACompleteNewTaskInputTheCreateTaskShouldCreateANewTask() throws Exception {
     // Given
     HttpTester.Request request = HttpTester.newRequest();
-    request.setHeader(HttpHeader.HOST.toString(), "test");
     request.setMethod(HttpMethod.POST.toString());
     request.setURI("/graphql/");
+    request.setHeader(HttpHeader.HOST.toString(), "test");
+    request.setHeader(HttpHeader.COOKIE.toString(), "ZM_AUTH_TOKEN=fake-user-cookie");
     request.setContent(
         TestUtils.queryPayload(
             "mutation { createTask(newTask: { "
@@ -102,9 +108,10 @@ public class CreateTaskApiIT {
   public void givenOnlyATitleTheCreateTaskShouldCreateANewTask() throws Exception {
     // Given
     HttpTester.Request request = HttpTester.newRequest();
-    request.setHeader(HttpHeader.HOST.toString(), "test");
     request.setMethod(HttpMethod.POST.toString());
     request.setURI("/graphql/");
+    request.setHeader(HttpHeader.HOST.toString(), "test");
+    request.setHeader(HttpHeader.COOKIE.toString(), "ZM_AUTH_TOKEN=fake-user-cookie");
     request.setContent(
         TestUtils.queryPayload(
             "mutation { createTask(newTask: { "
@@ -137,9 +144,10 @@ public class CreateTaskApiIT {
     // Given
     String longTitle = string1024chars + "a";
     HttpTester.Request request = HttpTester.newRequest();
-    request.setHeader(HttpHeader.HOST.toString(), "test");
     request.setMethod(HttpMethod.POST.toString());
     request.setURI("/graphql/");
+    request.setHeader(HttpHeader.HOST.toString(), "test");
+    request.setHeader(HttpHeader.COOKIE.toString(), "ZM_AUTH_TOKEN=fake-user-cookie");
     request.setContent(
         TestUtils.queryPayload(
             "mutation { createTask(newTask: { " + "title: \\\"" + longTitle + "\\\"" + "}) {id}}"));
@@ -167,9 +175,10 @@ public class CreateTaskApiIT {
     String longDescription =
         string1024chars + string1024chars + string1024chars + string1024chars + "a";
     HttpTester.Request request = HttpTester.newRequest();
-    request.setHeader(HttpHeader.HOST.toString(), "test");
     request.setMethod(HttpMethod.POST.toString());
     request.setURI("/graphql/");
+    request.setHeader(HttpHeader.HOST.toString(), "test");
+    request.setHeader(HttpHeader.COOKIE.toString(), "ZM_AUTH_TOKEN=fake-user-cookie");
     request.setContent(
         TestUtils.queryPayload(
             "mutation { createTask(newTask: { "
@@ -198,9 +207,10 @@ public class CreateTaskApiIT {
       throws Exception {
     // Given
     HttpTester.Request request = HttpTester.newRequest();
-    request.setHeader(HttpHeader.HOST.toString(), "test");
     request.setMethod(HttpMethod.POST.toString());
     request.setURI("/graphql/");
+    request.setHeader(HttpHeader.HOST.toString(), "test");
+    request.setHeader(HttpHeader.COOKIE.toString(), "ZM_AUTH_TOKEN=fake-user-cookie");
     request.setContent(
         TestUtils.queryPayload(
             "mutation { createTask(newTask: { "

--- a/core/src/test/java-it/com/zextras/carbonio/tasks/graphql/FindTasksApiIT.java
+++ b/core/src/test/java-it/com/zextras/carbonio/tasks/graphql/FindTasksApiIT.java
@@ -4,6 +4,7 @@
 
 package com.zextras.carbonio.tasks.graphql;
 
+import com.google.common.collect.ImmutableMap;
 import com.zextras.carbonio.tasks.Simulator;
 import com.zextras.carbonio.tasks.Simulator.SimulatorBuilder;
 import com.zextras.carbonio.tasks.TestUtils;
@@ -38,6 +39,10 @@ public class FindTasksApiIT {
             .init()
             .withDatabase()
             .withServiceDiscover()
+            .withUserManagement(
+                ImmutableMap.<String, String>builder()
+                    .put("fake-user-cookie", "00000000-0000-0000-0000-000000000000")
+                    .build())
             .withGraphQlServlet()
             .build()
             .start();
@@ -99,9 +104,10 @@ public class FindTasksApiIT {
         null);
 
     HttpTester.Request request = HttpTester.newRequest();
-    request.setHeader(HttpHeader.HOST.toString(), "test");
     request.setMethod(HttpMethod.POST.toString());
     request.setURI("/graphql/");
+    request.setHeader(HttpHeader.HOST.toString(), "test");
+    request.setHeader(HttpHeader.COOKIE.toString(), "ZM_AUTH_TOKEN=fake-user-cookie");
     request.setContent(
         TestUtils.queryPayload(
             "query{findTasks(status: OPEN){"
@@ -184,9 +190,10 @@ public class FindTasksApiIT {
         null);
 
     HttpTester.Request request = HttpTester.newRequest();
-    request.setHeader(HttpHeader.HOST.toString(), "test");
     request.setMethod(HttpMethod.POST.toString());
     request.setURI("/graphql/");
+    request.setHeader(HttpHeader.HOST.toString(), "test");
+    request.setHeader(HttpHeader.COOKIE.toString(), "ZM_AUTH_TOKEN=fake-user-cookie");
     request.setContent(
         TestUtils.queryPayload(
             "query{findTasks(priority: LOW){"
@@ -251,9 +258,10 @@ public class FindTasksApiIT {
         null);
 
     HttpTester.Request request = HttpTester.newRequest();
-    request.setHeader(HttpHeader.HOST.toString(), "test");
     request.setMethod(HttpMethod.POST.toString());
     request.setURI("/graphql/");
+    request.setHeader(HttpHeader.HOST.toString(), "test");
+    request.setHeader(HttpHeader.COOKIE.toString(), "ZM_AUTH_TOKEN=fake-user-cookie");
     request.setContent(
         TestUtils.queryPayload(
             "query{findTasks(status: COMPLETE, priority: HIGH){"
@@ -307,9 +315,10 @@ public class FindTasksApiIT {
         null);
 
     HttpTester.Request request = HttpTester.newRequest();
-    request.setHeader(HttpHeader.HOST.toString(), "test");
     request.setMethod(HttpMethod.POST.toString());
     request.setURI("/graphql/");
+    request.setHeader(HttpHeader.HOST.toString(), "test");
+    request.setHeader(HttpHeader.COOKIE.toString(), "ZM_AUTH_TOKEN=fake-user-cookie");
     request.setContent(
         TestUtils.queryPayload(
             "query{findTasks(status: COMPLETE, priority: MEDIUM){"

--- a/core/src/test/java-it/com/zextras/carbonio/tasks/graphql/GetTaskApiIT.java
+++ b/core/src/test/java-it/com/zextras/carbonio/tasks/graphql/GetTaskApiIT.java
@@ -4,6 +4,7 @@
 
 package com.zextras.carbonio.tasks.graphql;
 
+import com.google.common.collect.ImmutableMap;
 import com.zextras.carbonio.tasks.Simulator;
 import com.zextras.carbonio.tasks.Simulator.SimulatorBuilder;
 import com.zextras.carbonio.tasks.TestUtils;
@@ -36,6 +37,10 @@ public class GetTaskApiIT {
             .init()
             .withDatabase()
             .withServiceDiscover()
+            .withUserManagement(
+                ImmutableMap.<String, String>builder()
+                    .put("fake-user-cookie", "00000000-0000-0000-0000-000000000000")
+                    .build())
             .withGraphQlServlet()
             .build()
             .start();
@@ -89,6 +94,7 @@ public class GetTaskApiIT {
     request.setMethod(HttpMethod.POST.toString());
     request.setURI("/graphql/");
     request.setHeader(HttpHeader.HOST.toString(), "test");
+    request.setHeader(HttpHeader.COOKIE.toString(), "ZM_AUTH_TOKEN=fake-user-cookie");
     request.setContent(
         TestUtils.queryPayload(
             "query{getTask(taskId: \\\""
@@ -135,6 +141,7 @@ public class GetTaskApiIT {
     request.setMethod(HttpMethod.POST.toString());
     request.setURI("/graphql/");
     request.setHeader(HttpHeader.HOST.toString(), "test");
+    request.setHeader(HttpHeader.COOKIE.toString(), "ZM_AUTH_TOKEN=fake-user-cookie");
     request.setContent(
         TestUtils.queryPayload(
             "query{getTask(taskId: \\\"6d162bee-3186-1111-bf31-59746a41600e\\\"){"
@@ -177,6 +184,7 @@ public class GetTaskApiIT {
     request.setMethod(HttpMethod.POST.toString());
     request.setURI("/graphql/");
     request.setHeader(HttpHeader.HOST.toString(), "test");
+    request.setHeader(HttpHeader.COOKIE.toString(), "ZM_AUTH_TOKEN=fake-user-cookie");
     request.setContent(
         TestUtils.queryPayload(
             "query{getTask(taskId: \\\""

--- a/core/src/test/java-it/com/zextras/carbonio/tasks/graphql/ServiceInfoApiIT.java
+++ b/core/src/test/java-it/com/zextras/carbonio/tasks/graphql/ServiceInfoApiIT.java
@@ -4,6 +4,7 @@
 
 package com.zextras.carbonio.tasks.graphql;
 
+import com.google.common.collect.ImmutableMap;
 import com.zextras.carbonio.tasks.Simulator;
 import com.zextras.carbonio.tasks.Simulator.SimulatorBuilder;
 import com.zextras.carbonio.tasks.TestUtils;
@@ -26,7 +27,16 @@ public class ServiceInfoApiIT {
 
   @BeforeAll
   static void init() {
-    simulator = SimulatorBuilder.aSimulator().init().withGraphQlServlet().build().start();
+    simulator =
+        SimulatorBuilder.aSimulator()
+            .init()
+            .withGraphQlServlet()
+            .withUserManagement(
+                ImmutableMap.<String, String>builder()
+                    .put("fake-user-cookie", "00000000-0000-0000-0000-000000000000")
+                    .build())
+            .build()
+            .start();
     localConnector = simulator.getHttpLocalConnector();
   }
 
@@ -40,9 +50,10 @@ public class ServiceInfoApiIT {
       throws Exception {
     // Given
     HttpTester.Request request = HttpTester.newRequest();
-    request.setHeader(HttpHeader.HOST.toString(), "test");
     request.setMethod(HttpMethod.POST.toString());
     request.setURI("/graphql/");
+    request.setHeader(HttpHeader.HOST.toString(), "test");
+    request.setHeader(HttpHeader.COOKIE.toString(), "ZM_AUTH_TOKEN=fake-user-cookie");
     request.setContent(TestUtils.queryPayload("query{getServiceInfo{name version flavour}}"));
 
     // When

--- a/core/src/test/java-ut/com/zextras/carbonio/tasks/auth/AuthenticationServletFilterTest.java
+++ b/core/src/test/java-ut/com/zextras/carbonio/tasks/auth/AuthenticationServletFilterTest.java
@@ -1,0 +1,191 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.tasks.auth;
+
+import com.zextras.carbonio.tasks.Constants.Config.UserService;
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.model.HttpRequest;
+import org.mockserver.model.HttpResponse;
+import org.mockserver.verify.VerificationTimes;
+
+public class AuthenticationServletFilterTest {
+
+  static ClientAndServer userManagementServiceMock;
+
+  @BeforeAll
+  static void init() {
+    userManagementServiceMock = ClientAndServer.startClientAndServer(UserService.PORT);
+  }
+
+  @AfterEach
+  public void cleanUp() {
+    userManagementServiceMock.reset();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    userManagementServiceMock.stop();
+  }
+
+  @Test
+  public void givenAFilterConfigTheInitShouldInitializeTheFilter() throws ServletException {
+    // Given
+    FilterConfig filterConfigMock = Mockito.mock(FilterConfig.class);
+    Mockito.when(filterConfigMock.getServletContext())
+        .thenReturn(Mockito.mock(ServletContext.class));
+    AuthenticationServletFilter authenticationServletFilter = new AuthenticationServletFilter();
+
+    // When
+    authenticationServletFilter.init(filterConfigMock);
+
+    // Then
+    Mockito.verify(filterConfigMock, Mockito.times(1)).getServletContext();
+  }
+
+  @Test
+  public void givenARequestWithAValidCookieTheDoFilterShouldAddTheRequesterIdInTheServletContext()
+      throws ServletException, IOException {
+    // Given
+    Cookie[] cookies = {
+      new Cookie("ZM_AUTH_TOKEN", "zm-token"), new Cookie("ZX_AUTH_TOKEN", "zx-token")
+    };
+    HttpServletRequest httpRequestMock = Mockito.mock(HttpServletRequest.class);
+    Mockito.when(httpRequestMock.getCookies()).thenReturn(cookies);
+
+    HttpServletResponse httpResponseMock = Mockito.mock(HttpServletResponse.class);
+    FilterChain filterChainMock = Mockito.mock(FilterChain.class);
+
+    userManagementServiceMock
+        .when(
+            HttpRequest.request()
+                .withMethod(HttpMethod.GET.toString())
+                .withPath("/auth/token/zm-token"))
+        .respond(
+            HttpResponse.response()
+                .withStatusCode(HttpStatus.OK_200)
+                .withBody("{\"userId\": \"00000000-0000-0000-0000-000000000000\"}"));
+
+    AuthenticationServletFilter authenticationServletFilter = new AuthenticationServletFilter();
+
+    // When
+    authenticationServletFilter.doFilter(httpRequestMock, httpResponseMock, filterChainMock);
+
+    // Then
+    Mockito.verify(httpRequestMock, Mockito.times(1)).getCookies();
+
+    userManagementServiceMock.verify(
+        HttpRequest.request()
+            .withMethod(HttpMethod.GET.toString())
+            .withPath("/auth/token/zm-token"),
+        VerificationTimes.once());
+
+    Mockito.verify(httpRequestMock, Mockito.times(1))
+        .setAttribute("requesterId", "00000000-0000-0000-0000-000000000000");
+
+    Mockito.verify(filterChainMock, Mockito.times(1)).doFilter(httpRequestMock, httpResponseMock);
+  }
+
+  @Test
+  public void givenANotHttpRequestTheDoFilterShouldBlockTheRequest()
+      throws ServletException, IOException {
+    // Given
+    ServletRequest httpRequestMock = Mockito.mock(ServletRequest.class);
+    ServletResponse httpResponseMock = Mockito.mock(ServletResponse.class);
+    FilterChain filterChainMock = Mockito.mock(FilterChain.class);
+
+    AuthenticationServletFilter authenticationServletFilter = new AuthenticationServletFilter();
+
+    // When
+    authenticationServletFilter.doFilter(httpRequestMock, httpResponseMock, filterChainMock);
+
+    // Then
+    userManagementServiceMock.verifyZeroInteractions();
+    Mockito.verifyNoInteractions(httpRequestMock);
+    Mockito.verifyNoInteractions(httpResponseMock);
+    Mockito.verifyNoInteractions(filterChainMock);
+  }
+
+  @Test
+  public void givenARequestWithAnUnsupportedCookieTypeTheDoFilterShouldRespondWithA401StatusCode()
+      throws ServletException, IOException {
+    // Given
+    Cookie[] cookies = {new Cookie("UNSUPPORTED_COOKIE_TYPE", "zm-token")};
+    HttpServletRequest httpRequestMock = Mockito.mock(HttpServletRequest.class);
+    Mockito.when(httpRequestMock.getCookies()).thenReturn(cookies);
+    HttpServletResponse httpResponseMock = Mockito.mock(HttpServletResponse.class);
+    FilterChain filterChainMock = Mockito.mock(FilterChain.class);
+
+    AuthenticationServletFilter authenticationServletFilter = new AuthenticationServletFilter();
+
+    // When
+    authenticationServletFilter.doFilter(httpRequestMock, httpResponseMock, filterChainMock);
+
+    // Then
+    Mockito.verify(httpRequestMock, Mockito.times(1)).getCookies();
+    Mockito.verify(httpResponseMock, Mockito.times(1))
+        .setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+    userManagementServiceMock.verifyZeroInteractions();
+    Mockito.verify(httpRequestMock, Mockito.never())
+        .setAttribute(Mockito.anyString(), Mockito.anyString());
+    Mockito.verifyNoInteractions(filterChainMock);
+  }
+
+  @Test
+  public void givenARequestWithAnInvalidCookieTheDoFilterShouldRespondWithA401StatusCode()
+      throws ServletException, IOException {
+    // Given
+    Cookie[] cookies = {new Cookie("ZM_AUTH_TOKEN", "invalid-token")};
+    HttpServletRequest httpRequestMock = Mockito.mock(HttpServletRequest.class);
+    Mockito.when(httpRequestMock.getCookies()).thenReturn(cookies);
+    HttpServletResponse httpResponseMock = Mockito.mock(HttpServletResponse.class);
+    FilterChain filterChainMock = Mockito.mock(FilterChain.class);
+
+    userManagementServiceMock
+        .when(
+            HttpRequest.request()
+                .withMethod(HttpMethod.GET.toString())
+                .withPath("/auth/token/invalid-token"))
+        .respond(HttpResponse.response().withStatusCode(HttpStatus.UNAUTHORIZED_401));
+
+    AuthenticationServletFilter authenticationServletFilter = new AuthenticationServletFilter();
+
+    // When
+    authenticationServletFilter.doFilter(httpRequestMock, httpResponseMock, filterChainMock);
+
+    // Then
+    Mockito.verify(httpRequestMock, Mockito.times(1)).getCookies();
+
+    userManagementServiceMock.verify(
+        HttpRequest.request()
+            .withMethod(HttpMethod.GET.toString())
+            .withPath("/auth/token/invalid-token"),
+        VerificationTimes.once());
+
+    Mockito.verify(httpResponseMock, Mockito.times(1))
+        .setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+    Mockito.verify(httpRequestMock, Mockito.never())
+        .setAttribute(Mockito.anyString(), Mockito.anyString());
+    Mockito.verifyNoInteractions(filterChainMock);
+  }
+}

--- a/core/src/test/java-ut/com/zextras/carbonio/tasks/graphql/datafetchers/TaskDataFetchersTest.java
+++ b/core/src/test/java-ut/com/zextras/carbonio/tasks/graphql/datafetchers/TaskDataFetchersTest.java
@@ -8,6 +8,7 @@ import com.zextras.carbonio.tasks.dal.dao.Priority;
 import com.zextras.carbonio.tasks.dal.dao.Status;
 import com.zextras.carbonio.tasks.dal.dao.Task;
 import com.zextras.carbonio.tasks.dal.repositories.TaskRepository;
+import graphql.GraphQLContext;
 import graphql.execution.DataFetcherResult;
 import graphql.schema.DataFetchingEnvironment;
 import java.time.Instant;
@@ -48,9 +49,14 @@ public class TaskDataFetchersTest {
                 "00000000-0000-0000-0000-000000000000"))
         .thenReturn(Optional.of(requestedTaskMock));
 
+    GraphQLContext graphQLContextMock = Mockito.mock(GraphQLContext.class);
+    Mockito.when(graphQLContextMock.get("requesterId"))
+        .thenReturn("00000000-0000-0000-0000-000000000000");
+
     DataFetchingEnvironment environmentMock = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(environmentMock.getArgument("taskId"))
         .thenReturn("6d162bee-3186-0000-bf31-59746a41600e");
+    Mockito.when(environmentMock.getGraphQlContext()).thenReturn(graphQLContextMock);
 
     // When
     DataFetcherResult<Map<String, Object>> dataFetcherResult =
@@ -82,9 +88,14 @@ public class TaskDataFetchersTest {
                 "00000000-0000-0000-0000-000000000000"))
         .thenReturn(Optional.empty());
 
+    GraphQLContext graphQLContextMock = Mockito.mock(GraphQLContext.class);
+    Mockito.when(graphQLContextMock.get("requesterId"))
+        .thenReturn("00000000-0000-0000-0000-000000000000");
+
     DataFetchingEnvironment environmentMock = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(environmentMock.getArgument("taskId"))
         .thenReturn("6d162bee-3186-0000-bf31-59746a41600e");
+    Mockito.when(environmentMock.getGraphQlContext()).thenReturn(graphQLContextMock);
 
     // When
     DataFetcherResult<Map<String, Object>> dataFetcherResult =

--- a/core/src/test/java-ut/com/zextras/carbonio/tasks/graphql/instrumentations/ContextInstrumentationTest.java
+++ b/core/src/test/java-ut/com/zextras/carbonio/tasks/graphql/instrumentations/ContextInstrumentationTest.java
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.tasks.graphql.instrumentations;
+
+import graphql.GraphQLContext;
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
+import java.util.NoSuchElementException;
+import javax.servlet.http.HttpServletRequest;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class ContextInstrumentationTest {
+
+  @Test
+  public void
+      givenARequestWithARequesterIdAttributeTheInstrumentationShouldPutRequesterIdInGraphQLContext() {
+    // Given
+    HttpServletRequest requestMock = Mockito.mock(HttpServletRequest.class);
+    Mockito.when(requestMock.getAttribute("requesterId")).thenReturn("requester-uuid");
+
+    GraphQLContext graphQLContextMock = Mockito.mock(GraphQLContext.class);
+    Mockito.when(graphQLContextMock.get(HttpServletRequest.class)).thenReturn(requestMock);
+
+    InstrumentationExecutionParameters parametersMock =
+        Mockito.mock(InstrumentationExecutionParameters.class);
+    Mockito.when(parametersMock.getGraphQLContext()).thenReturn(graphQLContextMock);
+
+    ContextInstrumentation contextInstrumentation = new ContextInstrumentation();
+
+    // When
+    contextInstrumentation.beginExecution(parametersMock);
+
+    // Then
+    Mockito.verify(graphQLContextMock, Mockito.times(1)).put("requesterId", "requester-uuid");
+  }
+
+  @Test
+  public void givenANullRequestTheInstrumentationShouldThrowAnException() {
+    // Given
+    GraphQLContext graphQLContextMock = Mockito.mock(GraphQLContext.class);
+    Mockito.when(graphQLContextMock.get(HttpServletRequest.class)).thenReturn(null);
+
+    InstrumentationExecutionParameters parametersMock =
+        Mockito.mock(InstrumentationExecutionParameters.class);
+    Mockito.when(parametersMock.getGraphQLContext()).thenReturn(graphQLContextMock);
+
+    ContextInstrumentation contextInstrumentation = new ContextInstrumentation();
+
+    // When
+    ThrowableAssert.ThrowingCallable throwable =
+        () -> contextInstrumentation.beginExecution(parametersMock);
+
+    // Then
+    Assertions.assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(throwable);
+    Mockito.verify(graphQLContextMock, Mockito.never())
+        .put(Mockito.anyString(), Mockito.anyString());
+  }
+
+  @Test
+  public void givenARequestWithANullRequesterIdTheInstrumentationShouldThrowAnException() {
+    // Given
+    HttpServletRequest requestMock = Mockito.mock(HttpServletRequest.class);
+    Mockito.when(requestMock.getAttribute("requesterId")).thenReturn(null);
+
+    GraphQLContext graphQLContextMock = Mockito.mock(GraphQLContext.class);
+    Mockito.when(graphQLContextMock.get(HttpServletRequest.class)).thenReturn(requestMock);
+
+    InstrumentationExecutionParameters parametersMock =
+        Mockito.mock(InstrumentationExecutionParameters.class);
+    Mockito.when(parametersMock.getGraphQLContext()).thenReturn(graphQLContextMock);
+
+    ContextInstrumentation contextInstrumentation = new ContextInstrumentation();
+
+    // When
+    ThrowableAssert.ThrowingCallable throwable =
+        () -> contextInstrumentation.beginExecution(parametersMock);
+
+    // Then
+    Assertions.assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(throwable);
+    Mockito.verify(graphQLContextMock, Mockito.never())
+        .put(Mockito.anyString(), Mockito.anyString());
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <!-- Dependencies -->
     <assertj.version>3.23.1</assertj.version>
     <apache-httpclient.version>5.2.1</apache-httpclient.version>
+    <carbonio-user-management-sdk.version>0.1.3</carbonio-user-management-sdk.version>
     <ebean.version>13.14.0</ebean.version>
     <graphql-java-servlet.version>14.0.0</graphql-java-servlet.version>
     <guice.version>5.1.0</guice.version>
@@ -118,6 +119,13 @@ SPDX-License-Identifier: AGPL-3.0-only
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-servlet-initializer</artifactId>
         <version>${resteasy.version}</version>
+      </dependency>
+
+      <!-- Authentication -->
+      <dependency>
+        <groupId>com.zextras.carbonio.user-management</groupId>
+        <artifactId>carbonio-user-management-sdk</artifactId>
+        <version>${carbonio-user-management-sdk.version}</version>
       </dependency>
 
       <!-- Database -->
@@ -220,5 +228,13 @@ SPDX-License-Identifier: AGPL-3.0-only
       </dependency>
     </dependencies>
   </dependencyManagement>
+
+  <repositories>
+    <repository>
+      <id>zextras-java-sdk</id>
+      <name>Zextras public maven repo</name>
+      <url>https://zextras.jfrog.io/artifactory/java-sdk</url>
+    </repository>
+  </repositories>
 
 </project>


### PR DESCRIPTION
- Implemented a servlet filter to validate the GraphQL HTTP requests using the carbonio-user-management dependency
- Implemented the ContextInstrumentation class to avoid a dependency from HttpServletRequest attributes and the data fetchers. With this layer, each data fetcher can retrieve the requester id directly from the GraphQLContext
- Updated the Simulator to mock the user-management service and allow to create expectations for the cookie validations
- Added UTs and updated ITs

- In the pom.xml, added a new profile to run all tests and generate the jacoco full report