### PR TITLE
fix: TSK-39 - FindTasks should return only tasks in open state

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/tasks/dal/repositories/impl/TaskRepositoryEbean.java
+++ b/core/src/main/java/com/zextras/carbonio/tasks/dal/repositories/impl/TaskRepositoryEbean.java
@@ -85,9 +85,7 @@ public class TaskRepositoryEbean implements TaskRepository {
       query.eq(Tables.Task.PRIORITY, priority);
     }
 
-    if (status != null) {
-      query.eq(Tables.Task.STATUS, status);
-    }
+    query.eq(Tables.Task.STATUS, status == null ? Status.OPEN : status);
 
     return query.order().desc(Tables.Task.CREATED_AT).findList();
   }

--- a/core/src/test/java-ut/com/zextras/carbonio/tasks/dal/repositories/impl/TaskRepositoryEbeanTest.java
+++ b/core/src/test/java-ut/com/zextras/carbonio/tasks/dal/repositories/impl/TaskRepositoryEbeanTest.java
@@ -222,7 +222,7 @@ class TaskRepositoryEbeanTest {
   }
 
   @Test
-  void givenAUserTheGetTasksShouldReturnAListOfTasks() {
+  void givenAUserTheGetTasksShouldReturnAListOfOpenTasks() {
     // Given
     Task taskMock = Mockito.mock(Task.class);
     ExpressionList<Task> partialQueryMock = Mockito.mock(ExpressionList.class);
@@ -236,6 +236,7 @@ class TaskRepositoryEbeanTest {
                 .eq("user_id", "6d162bee-3186-1111-bf31-59746a41600e"))
         .thenReturn(partialQueryMock);
 
+    Mockito.when(partialQueryMock.eq("status", Status.OPEN)).thenReturn(partialQueryMock);
     Mockito.when(partialQueryMock.order()).thenReturn(orderByMock);
     Mockito.when(orderByMock.desc("created_at")).thenReturn(finalQueryMock);
     Mockito.when(finalQueryMock.findList()).thenReturn(Collections.singletonList(taskMock));


### PR DESCRIPTION
In the FindTask API when a client does not specify the status, the system should return only tasks in an open state