### PR TITLE
feat: TSK-56 - Update FindTasks to return even the completed tasks

### DIFF
--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -24,7 +24,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.tasks</groupId>
     <artifactId>carbonio-tasks-ce</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -24,7 +24,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.tasks</groupId>
     <artifactId>carbonio-tasks-ce</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/core/src/main/java/com/zextras/carbonio/tasks/dal/repositories/impl/TaskRepositoryEbean.java
+++ b/core/src/main/java/com/zextras/carbonio/tasks/dal/repositories/impl/TaskRepositoryEbean.java
@@ -85,7 +85,9 @@ public class TaskRepositoryEbean implements TaskRepository {
       query.eq(Tables.Task.PRIORITY, priority);
     }
 
-    query.eq(Tables.Task.STATUS, status == null ? Status.OPEN : status);
+    if (status != null) {
+      query.eq(Tables.Task.STATUS, status);
+    }
 
     return query.order().desc(Tables.Task.CREATED_AT).findList();
   }

--- a/core/src/test/java-it/com/zextras/carbonio/tasks/graphql/FindTasksApiIT.java
+++ b/core/src/test/java-it/com/zextras/carbonio/tasks/graphql/FindTasksApiIT.java
@@ -150,7 +150,7 @@ class FindTasksApiIT {
   }
 
   @Test
-  void givenAnEmptyStatusTheFindTasksShouldReturnTheTasksOfTheRequesterInAOpenState()
+  void givenAnEmptyStatusTheFindTasksShouldReturnTheTasksOfTheRequesterInAOpenAndCompleteState()
       throws Exception {
     // Given
     Task task1 =
@@ -173,14 +173,15 @@ class FindTasksApiIT {
             null,
             null);
 
-    taskRepository.createTask(
-        "00000000-0000-0000-0000-000000000000",
-        "title3",
-        null,
-        Priority.HIGH,
-        Status.COMPLETE,
-        null,
-        null);
+    Task task3 =
+        taskRepository.createTask(
+            "00000000-0000-0000-0000-000000000000",
+            "title3",
+            null,
+            Priority.HIGH,
+            Status.COMPLETE,
+            null,
+            null);
 
     taskRepository.createTask(
         "11111111-1111-1111-1111-111111111111",
@@ -212,10 +213,21 @@ class FindTasksApiIT {
     List<Map<String, Object>> findTasks =
         TestUtils.jsonResponseToList(response.getContent(), "findTasks");
 
-    Assertions.assertThat(findTasks).isNotNull().hasSize(2);
+    Assertions.assertThat(findTasks).isNotNull().hasSize(3);
 
     Map<String, Object> result1 = findTasks.get(0);
     Assertions.assertThat(result1)
+        .containsEntry("id", task3.getId().toString())
+        .containsEntry("title", "title3")
+        .containsEntry("description", null)
+        .containsEntry("priority", "HIGH")
+        .containsEntry("status", "COMPLETE")
+        .containsEntry("createdAt", task3.getCreatedAt().toEpochMilli())
+        .containsEntry("reminderAt", null)
+        .containsEntry("reminderAllDay", null);
+
+    Map<String, Object> result2 = findTasks.get(1);
+    Assertions.assertThat(result2)
         .containsEntry("id", task2.getId().toString())
         .containsEntry("title", "title2")
         .containsEntry("description", null)
@@ -225,8 +237,8 @@ class FindTasksApiIT {
         .containsEntry("reminderAt", null)
         .containsEntry("reminderAllDay", null);
 
-    Map<String, Object> result2 = findTasks.get(1);
-    Assertions.assertThat(result2)
+    Map<String, Object> result3 = findTasks.get(2);
+    Assertions.assertThat(result3)
         .containsEntry("id", task1.getId().toString())
         .containsEntry("title", "title1")
         .containsEntry("description", null)
@@ -250,7 +262,7 @@ class FindTasksApiIT {
         null,
         null);
 
-    Task task =
+    Task task1 =
         taskRepository.createTask(
             "00000000-0000-0000-0000-000000000000",
             "title2",
@@ -260,14 +272,15 @@ class FindTasksApiIT {
             null,
             null);
 
-    taskRepository.createTask(
-        "00000000-0000-0000-0000-000000000000",
-        "title3",
-        null,
-        Priority.HIGH,
-        Status.COMPLETE,
-        null,
-        null);
+    Task task2 =
+        taskRepository.createTask(
+            "00000000-0000-0000-0000-000000000000",
+            "title3",
+            null,
+            Priority.LOW,
+            Status.COMPLETE,
+            null,
+            null);
 
     taskRepository.createTask(
         "11111111-1111-1111-1111-111111111111",
@@ -299,16 +312,27 @@ class FindTasksApiIT {
     List<Map<String, Object>> findTasks =
         TestUtils.jsonResponseToList(response.getContent(), "findTasks");
 
-    Assertions.assertThat(findTasks).isNotNull().hasSize(1);
+    Assertions.assertThat(findTasks).isNotNull().hasSize(2);
 
     Map<String, Object> result1 = findTasks.get(0);
     Assertions.assertThat(result1)
-        .containsEntry("id", task.getId().toString())
+        .containsEntry("id", task2.getId().toString())
+        .containsEntry("title", "title3")
+        .containsEntry("description", null)
+        .containsEntry("priority", "LOW")
+        .containsEntry("status", "COMPLETE")
+        .containsEntry("createdAt", task2.getCreatedAt().toEpochMilli())
+        .containsEntry("reminderAt", null)
+        .containsEntry("reminderAllDay", null);
+
+    Map<String, Object> result2 = findTasks.get(1);
+    Assertions.assertThat(result2)
+        .containsEntry("id", task1.getId().toString())
         .containsEntry("title", "title2")
         .containsEntry("description", null)
         .containsEntry("priority", "LOW")
         .containsEntry("status", "OPEN")
-        .containsEntry("createdAt", task.getCreatedAt().toEpochMilli())
+        .containsEntry("createdAt", task1.getCreatedAt().toEpochMilli())
         .containsEntry("reminderAt", null)
         .containsEntry("reminderAllDay", null);
   }

--- a/core/src/test/java-ut/com/zextras/carbonio/tasks/dal/repositories/impl/TaskRepositoryEbeanTest.java
+++ b/core/src/test/java-ut/com/zextras/carbonio/tasks/dal/repositories/impl/TaskRepositoryEbeanTest.java
@@ -106,7 +106,7 @@ class TaskRepositoryEbeanTest {
   }
 
   @Test
-  void givenAUserAStatusAPriorityTheGetTasksShouldReturnAListOfTasks() {
+  void givenAUserIdAStatusAPriorityTheGetTasksShouldReturnAListOfTasks() {
     // Given
     Task taskMock1 = Mockito.mock(Task.class);
     Task taskMock2 = Mockito.mock(Task.class);
@@ -121,8 +121,6 @@ class TaskRepositoryEbeanTest {
                 .eq("user_id", "6d162bee-3186-1111-bf31-59746a41600e"))
         .thenReturn(partialQueryMock);
 
-    Mockito.when(partialQueryMock.eq("priority", Priority.MEDIUM)).thenReturn(partialQueryMock);
-    Mockito.when(partialQueryMock.eq("status", Status.OPEN)).thenReturn(partialQueryMock);
     Mockito.when(partialQueryMock.order()).thenReturn(orderByMock);
     Mockito.when(orderByMock.desc("created_at")).thenReturn(finalQueryMock);
     Mockito.when(finalQueryMock.findList()).thenReturn(Arrays.asList(taskMock1, taskMock2));
@@ -134,10 +132,13 @@ class TaskRepositoryEbeanTest {
 
     // Then
     Assertions.assertThat(openTasks).hasSize(2);
+
+    Mockito.verify(partialQueryMock, Mockito.times(1)).eq("priority", Priority.MEDIUM);
+    Mockito.verify(partialQueryMock, Mockito.times(1)).eq("status", Status.OPEN);
   }
 
   @Test
-  void givenAUserAStatusAPriorityTheGetTasksShouldReturnAnEmptyList() {
+  void givenAUserIdAStatusAPriorityTheGetTasksShouldReturnAnEmptyList() {
     // Given
     ExpressionList<Task> partialQueryMock = Mockito.mock(ExpressionList.class);
     OrderBy<Task> orderByMock = Mockito.mock(OrderBy.class);
@@ -150,8 +151,6 @@ class TaskRepositoryEbeanTest {
                 .eq("user_id", "6d162bee-3186-1111-bf31-59746a41600e"))
         .thenReturn(partialQueryMock);
 
-    Mockito.when(partialQueryMock.eq("priority", Priority.MEDIUM)).thenReturn(partialQueryMock);
-    Mockito.when(partialQueryMock.eq("status", Status.OPEN)).thenReturn(partialQueryMock);
     Mockito.when(partialQueryMock.order()).thenReturn(orderByMock);
     Mockito.when(orderByMock.desc("created_at")).thenReturn(finalQueryMock);
     Mockito.when(finalQueryMock.findList()).thenReturn(Collections.emptyList());
@@ -162,11 +161,14 @@ class TaskRepositoryEbeanTest {
             "6d162bee-3186-1111-bf31-59746a41600e", Priority.LOW, Status.COMPLETE);
 
     // Then
-    Assertions.assertThat(openTasks).isEmpty();
+    Assertions.assertThat(openTasks).hasSize(0);
+
+    Mockito.verify(partialQueryMock, Mockito.times(1)).eq("priority", Priority.LOW);
+    Mockito.verify(partialQueryMock, Mockito.times(1)).eq("status", Status.COMPLETE);
   }
 
   @Test
-  void givenAUserAStatusTheGetTasksShouldReturnAListOfTasks() {
+  void givenAUserIdAStatusTheGetTasksShouldReturnAListOfTasks() {
     // Given
     Task taskMock = Mockito.mock(Task.class);
     ExpressionList<Task> partialQueryMock = Mockito.mock(ExpressionList.class);
@@ -180,7 +182,6 @@ class TaskRepositoryEbeanTest {
                 .eq("user_id", "6d162bee-3186-1111-bf31-59746a41600e"))
         .thenReturn(partialQueryMock);
 
-    Mockito.when(partialQueryMock.eq("status", Status.OPEN)).thenReturn(partialQueryMock);
     Mockito.when(partialQueryMock.order()).thenReturn(orderByMock);
     Mockito.when(orderByMock.desc("created_at")).thenReturn(finalQueryMock);
     Mockito.when(finalQueryMock.findList()).thenReturn(Collections.singletonList(taskMock));
@@ -191,10 +192,14 @@ class TaskRepositoryEbeanTest {
 
     // Then
     Assertions.assertThat(openTasks).hasSize(1);
+
+    Mockito.verify(partialQueryMock, Mockito.times(0))
+        .eq(Mockito.eq("priority"), Mockito.anyString());
+    Mockito.verify(partialQueryMock, Mockito.times(1)).eq("status", Status.COMPLETE);
   }
 
   @Test
-  void givenAUserAPriorityTheGetTasksShouldReturnAListOfTasks() {
+  void givenAUserIdAPriorityTheGetTasksShouldReturnAListOfTasks() {
     // Given
     Task taskMock = Mockito.mock(Task.class);
     ExpressionList<Task> partialQueryMock = Mockito.mock(ExpressionList.class);
@@ -208,7 +213,6 @@ class TaskRepositoryEbeanTest {
                 .eq("user_id", "6d162bee-3186-1111-bf31-59746a41600e"))
         .thenReturn(partialQueryMock);
 
-    Mockito.when(partialQueryMock.eq("status", Priority.HIGH)).thenReturn(partialQueryMock);
     Mockito.when(partialQueryMock.order()).thenReturn(orderByMock);
     Mockito.when(orderByMock.desc("created_at")).thenReturn(finalQueryMock);
     Mockito.when(finalQueryMock.findList()).thenReturn(Collections.singletonList(taskMock));
@@ -219,10 +223,13 @@ class TaskRepositoryEbeanTest {
 
     // Then
     Assertions.assertThat(openTasks).hasSize(1);
+
+    Mockito.verify(partialQueryMock, Mockito.times(1)).eq("priority", Priority.HIGH);
+    Mockito.verify(partialQueryMock, Mockito.times(1)).eq("status", Status.OPEN);
   }
 
   @Test
-  void givenAUserTheGetTasksShouldReturnAListOfOpenTasks() {
+  void givenAUserIdTheGetTasksShouldReturnAListOfOpenTasks() {
     // Given
     Task taskMock = Mockito.mock(Task.class);
     ExpressionList<Task> partialQueryMock = Mockito.mock(ExpressionList.class);
@@ -236,17 +243,20 @@ class TaskRepositoryEbeanTest {
                 .eq("user_id", "6d162bee-3186-1111-bf31-59746a41600e"))
         .thenReturn(partialQueryMock);
 
-    Mockito.when(partialQueryMock.eq("status", Status.OPEN)).thenReturn(partialQueryMock);
     Mockito.when(partialQueryMock.order()).thenReturn(orderByMock);
     Mockito.when(orderByMock.desc("created_at")).thenReturn(finalQueryMock);
     Mockito.when(finalQueryMock.findList()).thenReturn(Collections.singletonList(taskMock));
 
     // When
     List<Task> openTasks =
-        taskRepository.getTasks("6d162bee-3186-1111-bf31-59746a41600e", Priority.HIGH, null);
+        taskRepository.getTasks("6d162bee-3186-1111-bf31-59746a41600e", null, null);
 
     // Then
     Assertions.assertThat(openTasks).hasSize(1);
+
+    Mockito.verify(partialQueryMock, Mockito.times(0))
+        .eq(Mockito.eq("priority"), Mockito.anyString());
+    Mockito.verify(partialQueryMock, Mockito.times(1)).eq("status", Status.OPEN);
   }
 
   @Test
@@ -278,10 +288,10 @@ class TaskRepositoryEbeanTest {
             ebeanDatabaseMock
                 .find(Task.class)
                 .where()
-                .idEq(UUID.fromString("6d162bee-3186-0000-bf31-59746a41600e"))
+                .idEq(UUID.fromString("00000000-3186-0000-bf31-59746a41600e"))
                 .eq("user_id", "6d162bee-3186-1111-bf31-59746a41600e")
                 .findOneOrEmpty())
-        .thenReturn(Optional.of(Mockito.mock(Task.class)));
+        .thenReturn(Optional.empty());
 
     // When
     Optional<Task> optTask =

--- a/core/src/test/java-ut/com/zextras/carbonio/tasks/dal/repositories/impl/TaskRepositoryEbeanTest.java
+++ b/core/src/test/java-ut/com/zextras/carbonio/tasks/dal/repositories/impl/TaskRepositoryEbeanTest.java
@@ -225,7 +225,8 @@ class TaskRepositoryEbeanTest {
     Assertions.assertThat(openTasks).hasSize(1);
 
     Mockito.verify(partialQueryMock, Mockito.times(1)).eq("priority", Priority.HIGH);
-    Mockito.verify(partialQueryMock, Mockito.times(1)).eq("status", Status.OPEN);
+    Mockito.verify(partialQueryMock, Mockito.times(0))
+        .eq(Mockito.eq("status"), Mockito.anyString());
   }
 
   @Test
@@ -256,7 +257,9 @@ class TaskRepositoryEbeanTest {
 
     Mockito.verify(partialQueryMock, Mockito.times(0))
         .eq(Mockito.eq("priority"), Mockito.anyString());
-    Mockito.verify(partialQueryMock, Mockito.times(1)).eq("status", Status.OPEN);
+
+    Mockito.verify(partialQueryMock, Mockito.times(0))
+        .eq(Mockito.eq("status"), Mockito.anyString());
   }
 
   @Test

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -7,7 +7,7 @@ targets=(
   "centos"
 )
 pkgname="carbonio-tasks-ce"
-pkgver="0.1.0"
+pkgver="0.2.0"
 pkgrel="SNAPSHOT"
 pkgdesc="Carbonio Tasks"
 pkgdesclong=(

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
   <groupId>com.zextras.carbonio.tasks</groupId>
   <artifactId>carbonio-tasks-ce</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>carbonio-tasks-ce</name>


### PR DESCRIPTION
[chore: bump version to snapshot](https://github.com/zextras/carbonio-tasks-ce/commit/83158aa30ebb0fe831b0b296117dc0528d5ca978)

---

[test: fix TaskRepositoryEbeanTest making it more prone to fail when the eBean query change](https://github.com/zextras/carbonio-tasks-ce/commit/b2414a596d1d32f488f04ac97924ee838e6a6d95)

---

[feat: update FindTasks to return all tasks when the status is not given](https://github.com/zextras/carbonio-tasks-ce/commit/1f6815150b63433b1b98cf355ebf5ddd3d1e68fb)
- Updated TaskRepositoryEbean#getTasks to return both opened and
  completed tasks of a user when the client does not specify the status
  attribute in the FindTasks API. When the client specify the status
  the TaskRepositoryEbean#getTasks applies the filter.
- Fixed failing UTs and ITs

refs: TSK56