### PR TITLE
feat: TSK-57 - Implement TrashTask API to mark a task as trashed 

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/tasks/Constants.java
+++ b/core/src/main/java/com/zextras/carbonio/tasks/Constants.java
@@ -213,5 +213,12 @@ public final class Constants {
 
       private Mutations() {}
     }
+
+    public static final class ErrorMessages {
+
+      public static final String TASK_NOT_FOUND = "Could not find task with id %s";
+
+      private ErrorMessages() {}
+    }
   }
 }

--- a/core/src/main/java/com/zextras/carbonio/tasks/Constants.java
+++ b/core/src/main/java/com/zextras/carbonio/tasks/Constants.java
@@ -209,6 +209,7 @@ public final class Constants {
 
       public static final String CREATE_TASK = "createTask";
       public static final String UPDATE_TASK = "updateTask";
+      public static final String TRASH_TASK = "trashTask";
 
       private Mutations() {}
     }

--- a/core/src/main/java/com/zextras/carbonio/tasks/dal/dao/Status.java
+++ b/core/src/main/java/com/zextras/carbonio/tasks/dal/dao/Status.java
@@ -10,5 +10,6 @@ package com.zextras.carbonio.tasks.dal.dao;
  */
 public enum Status {
   OPEN,
-  COMPLETE
+  COMPLETE,
+  TRASH
 }

--- a/core/src/main/java/com/zextras/carbonio/tasks/dal/repositories/impl/TaskRepositoryEbean.java
+++ b/core/src/main/java/com/zextras/carbonio/tasks/dal/repositories/impl/TaskRepositoryEbean.java
@@ -69,6 +69,7 @@ public class TaskRepositoryEbean implements TaskRepository {
         .where()
         .idEq(taskId)
         .eq(Tables.Task.USER_ID, userId)
+        .ne(Tables.Task.STATUS, Status.TRASH)
         .findOneOrEmpty();
   }
 
@@ -87,6 +88,8 @@ public class TaskRepositoryEbean implements TaskRepository {
 
     if (status != null) {
       query.eq(Tables.Task.STATUS, status);
+    } else {
+      query.ne(Tables.Task.STATUS, Status.TRASH);
     }
 
     return query.order().desc(Tables.Task.CREATED_AT).findList();

--- a/core/src/main/java/com/zextras/carbonio/tasks/graphql/GraphQLProvider.java
+++ b/core/src/main/java/com/zextras/carbonio/tasks/graphql/GraphQLProvider.java
@@ -113,7 +113,8 @@ public class GraphQLProvider {
         .type(
             newTypeWiring("Mutation")
                 .dataFetcher(Mutations.CREATE_TASK, taskDataFetchers.createTask())
-                .dataFetcher(Mutations.UPDATE_TASK, taskDataFetchers.updateTask()))
+                .dataFetcher(Mutations.UPDATE_TASK, taskDataFetchers.updateTask())
+                .dataFetcher(Mutations.TRASH_TASK, taskDataFetchers.trashTask()))
         .build();
   }
 

--- a/core/src/main/java/com/zextras/carbonio/tasks/graphql/datafetchers/TaskDataFetchers.java
+++ b/core/src/main/java/com/zextras/carbonio/tasks/graphql/datafetchers/TaskDataFetchers.java
@@ -8,6 +8,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.zextras.carbonio.tasks.Constants.GraphQL;
 import com.zextras.carbonio.tasks.Constants.GraphQL.Context;
+import com.zextras.carbonio.tasks.Constants.GraphQL.ErrorMessages;
 import com.zextras.carbonio.tasks.Constants.GraphQL.Inputs;
 import com.zextras.carbonio.tasks.Constants.GraphQL.Inputs.TaskInput;
 import com.zextras.carbonio.tasks.dal.dao.Priority;
@@ -81,7 +82,7 @@ public class TaskDataFetchers {
                 return DataFetcherResult.<Map<String, Object>>newResult()
                     .error(
                         GraphqlErrorBuilder.newError()
-                            .message(String.format("Could not find task with id %s", taskId))
+                            .message(String.format(ErrorMessages.TASK_NOT_FOUND, taskId))
                             .build())
                     .build();
               }
@@ -136,7 +137,7 @@ public class TaskDataFetchers {
                       DataFetcherResult.<Map<String, Object>>newResult()
                           .error(
                               GraphqlErrorBuilder.newError()
-                                  .message(String.format("Could not find task with id %s", taskId))
+                                  .message(String.format(ErrorMessages.TASK_NOT_FOUND, taskId))
                                   .build())
                           .build());
             });
@@ -176,7 +177,7 @@ public class TaskDataFetchers {
                       DataFetcherResult.<UUID>newResult()
                           .error(
                               GraphqlErrorBuilder.newError()
-                                  .message(String.format("Could not find task with id %s", taskId))
+                                  .message(String.format(ErrorMessages.TASK_NOT_FOUND, taskId))
                                   .build())
                           .build());
             });

--- a/core/src/main/resources/api/schema.graphql
+++ b/core/src/main/resources/api/schema.graphql
@@ -88,4 +88,6 @@ type Mutation {
     createTask(newTask: NewTaskInput!): Task
 
     updateTask(updateTask: UpdateTaskInput!): Task
+
+    trashTask(taskId: ID!): ID
 }

--- a/core/src/test/java-it/com/zextras/carbonio/tasks/TestUtils.java
+++ b/core/src/test/java-it/com/zextras/carbonio/tasks/TestUtils.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class TestUtils {
@@ -57,6 +58,22 @@ public class TestUtils {
 
     } catch (JsonProcessingException exception) {
       return Collections.emptyList();
+    }
+  }
+
+  public static Optional<String> jsonResponseToString(String json, String operation) {
+    try {
+      Map<String, Object> result = new ObjectMapper().readValue(json, Map.class);
+
+      if (result.get("data") != null) {
+        Map<String, Object> data = (Map<String, Object>) result.get("data");
+
+        return Optional.ofNullable((String) data.get(operation));
+      }
+      return Optional.empty();
+
+    } catch (JsonProcessingException exception) {
+      return Optional.empty();
     }
   }
 

--- a/core/src/test/java-it/com/zextras/carbonio/tasks/graphql/FindTasksApiIT.java
+++ b/core/src/test/java-it/com/zextras/carbonio/tasks/graphql/FindTasksApiIT.java
@@ -184,6 +184,15 @@ class FindTasksApiIT {
             null);
 
     taskRepository.createTask(
+        "00000000-0000-0000-0000-000000000000",
+        "Trash task",
+        null,
+        Priority.LOW,
+        Status.TRASH,
+        null,
+        null);
+
+    taskRepository.createTask(
         "11111111-1111-1111-1111-111111111111",
         "titleX",
         null,
@@ -281,6 +290,15 @@ class FindTasksApiIT {
             Status.COMPLETE,
             null,
             null);
+
+    taskRepository.createTask(
+        "00000000-0000-0000-0000-000000000000",
+        "Trash task",
+        null,
+        Priority.LOW,
+        Status.TRASH,
+        null,
+        null);
 
     taskRepository.createTask(
         "11111111-1111-1111-1111-111111111111",
@@ -423,6 +441,15 @@ class FindTasksApiIT {
         null,
         Priority.HIGH,
         Status.COMPLETE,
+        null,
+        null);
+
+    taskRepository.createTask(
+        "00000000-0000-0000-0000-000000000000",
+        "Trash task",
+        null,
+        Priority.MEDIUM,
+        Status.TRASH,
         null,
         null);
 

--- a/core/src/test/java-it/com/zextras/carbonio/tasks/graphql/TrashTaskApiIT.java
+++ b/core/src/test/java-it/com/zextras/carbonio/tasks/graphql/TrashTaskApiIT.java
@@ -86,6 +86,9 @@ public class TrashTaskApiIT {
     Optional<String> optStringResponse =
         TestUtils.jsonResponseToString(response.getContent(), "trashTask");
     Assertions.assertThat(optStringResponse).isPresent().contains(taskToTrash.getId().toString());
+
+    Assertions.assertThat(taskRepository.getTask(taskToTrash.getId(), taskToTrash.getUserId()))
+        .isEmpty();
   }
 
   @Test
@@ -148,5 +151,9 @@ public class TrashTaskApiIT {
     Assertions.assertThat(errors)
         .hasSize(1)
         .contains(String.format("Could not find task with id %s", taskToTrash.getId().toString()));
+
+    Optional<Task> optTask = taskRepository.getTask(taskToTrash.getId(), taskToTrash.getUserId());
+    Assertions.assertThat(optTask).isPresent();
+    Assertions.assertThat(optTask.get().getStatus()).isEqualTo(Status.OPEN);
   }
 }

--- a/core/src/test/java-it/com/zextras/carbonio/tasks/graphql/TrashTaskApiIT.java
+++ b/core/src/test/java-it/com/zextras/carbonio/tasks/graphql/TrashTaskApiIT.java
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.tasks.graphql;
+
+import com.zextras.carbonio.tasks.Simulator;
+import com.zextras.carbonio.tasks.Simulator.SimulatorBuilder;
+import com.zextras.carbonio.tasks.TestUtils;
+import com.zextras.carbonio.tasks.dal.dao.Priority;
+import com.zextras.carbonio.tasks.dal.dao.Status;
+import com.zextras.carbonio.tasks.dal.dao.Task;
+import com.zextras.carbonio.tasks.dal.repositories.TaskRepository;
+import java.util.List;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.server.LocalConnector;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
+
+public class TrashTaskApiIT {
+
+  static Simulator simulator;
+  static LocalConnector httpLocalConnector;
+  static TaskRepository taskRepository;
+  static String REQUESTER_COOKIE = "ZM_AUTH_TOKEN=fake-user-cookie";
+  static String REQUESTER_ID = "0c07cb53-f942-4644-8166-fb1d3e41faf3";
+
+  @BeforeAll
+  static void init() {
+    simulator =
+        SimulatorBuilder.aSimulator()
+            .init()
+            .withDatabase()
+            .withServiceDiscover()
+            .withUserManagement(ImmutableMap.of("fake-user-cookie", REQUESTER_ID))
+            .withServer()
+            .build()
+            .start();
+
+    httpLocalConnector = simulator.getHttpLocalConnector();
+    taskRepository = simulator.getInjector().getInstance(TaskRepository.class);
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    simulator.stopAll();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    simulator.resetDatabase();
+  }
+
+  @Test
+  void
+      givenAnExistingTaskIdTheTrashTaskApiShouldMarkItAsDeletedAndReturn200WithTheIdOfTheTrashedTask()
+          throws Exception {
+    // Given
+    Task taskToTrash =
+        taskRepository.createTask(
+            REQUESTER_ID, "title1", "description", Priority.HIGH, Status.OPEN, null, null);
+
+    HttpTester.Request request = HttpTester.newRequest();
+    request.setMethod(HttpMethod.POST.toString());
+    request.setURI("/graphql/");
+    request.setHeader(HttpHeader.HOST.toString(), "test");
+    request.setHeader(HttpHeader.COOKIE.toString(), REQUESTER_COOKIE);
+    request.setContent(
+        TestUtils.queryPayload(
+            "mutation { trashTask(taskId: \\\"" + taskToTrash.getId().toString() + "\\\") }"));
+
+    // When
+    HttpTester.Response response =
+        HttpTester.parseResponse(httpLocalConnector.getResponse(request.generate()));
+
+    // Then
+    Assertions.assertThat(response.getStatus()).isEqualTo(200);
+
+    Optional<String> optStringResponse =
+        TestUtils.jsonResponseToString(response.getContent(), "trashTask");
+    Assertions.assertThat(optStringResponse).isPresent().contains(taskToTrash.getId().toString());
+  }
+
+  @Test
+  void givenANotExistingTaskIdTheTrashTaskApiShouldReturn200WithAnErrorMessage() throws Exception {
+    // Given
+    HttpTester.Request request = HttpTester.newRequest();
+    request.setMethod(HttpMethod.POST.toString());
+    request.setURI("/graphql/");
+    request.setHeader(HttpHeader.HOST.toString(), "test");
+    request.setHeader(HttpHeader.COOKIE.toString(), REQUESTER_COOKIE);
+    request.setContent(
+        TestUtils.queryPayload(
+            "mutation { trashTask(taskId: \\\"1e39756c-bd40-4381-8415-af4244d7a3e8\\\") }"));
+
+    // When
+    HttpTester.Response response =
+        HttpTester.parseResponse(httpLocalConnector.getResponse(request.generate()));
+
+    // Then
+    Assertions.assertThat(response.getStatus()).isEqualTo(200);
+
+    List<String> errors = TestUtils.jsonResponseToErrors(response.getContent());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .contains("Could not find task with id 1e39756c-bd40-4381-8415-af4244d7a3e8");
+  }
+
+  @Test
+  void givenAnExistingTaskIdOfAnotherUserTheTrashTaskApiShouldReturn200WithAErrorMessage()
+      throws Exception {
+    // Given
+
+    Task taskToTrash =
+        taskRepository.createTask(
+            "00000000-0000-0000-0000-000000000000",
+            "title1",
+            "description",
+            Priority.HIGH,
+            Status.OPEN,
+            null,
+            null);
+
+    HttpTester.Request request = HttpTester.newRequest();
+    request.setMethod(HttpMethod.POST.toString());
+    request.setURI("/graphql/");
+    request.setHeader(HttpHeader.HOST.toString(), "test");
+    request.setHeader(HttpHeader.COOKIE.toString(), REQUESTER_COOKIE);
+    request.setContent(
+        TestUtils.queryPayload(
+            "mutation { trashTask(taskId: \\\"" + taskToTrash.getId().toString() + "\\\") }"));
+
+    // When
+    HttpTester.Response response =
+        HttpTester.parseResponse(httpLocalConnector.getResponse(request.generate()));
+
+    // Then
+    Assertions.assertThat(response.getStatus()).isEqualTo(200);
+
+    List<String> errors = TestUtils.jsonResponseToErrors(response.getContent());
+    Assertions.assertThat(errors)
+        .hasSize(1)
+        .contains(String.format("Could not find task with id %s", taskToTrash.getId().toString()));
+  }
+}

--- a/core/src/test/java-ut/com/zextras/carbonio/tasks/dal/repositories/impl/TaskRepositoryEbeanTest.java
+++ b/core/src/test/java-ut/com/zextras/carbonio/tasks/dal/repositories/impl/TaskRepositoryEbeanTest.java
@@ -106,7 +106,8 @@ class TaskRepositoryEbeanTest {
   }
 
   @Test
-  void givenAUserIdAStatusAPriorityTheGetTasksShouldReturnAListOfTasks() {
+  void
+      givenAUserIdAStatusMediumAPriorityOpenTheGetTasksShouldReturnAListOfOpenedTasksWithMediumPriority() {
     // Given
     Task taskMock1 = Mockito.mock(Task.class);
     Task taskMock2 = Mockito.mock(Task.class);
@@ -168,7 +169,7 @@ class TaskRepositoryEbeanTest {
   }
 
   @Test
-  void givenAUserIdAStatusTheGetTasksShouldReturnAListOfTasks() {
+  void givenAUserIdAStatusCompleteTheGetTasksShouldReturnAListOfCompletedTasks() {
     // Given
     Task taskMock = Mockito.mock(Task.class);
     ExpressionList<Task> partialQueryMock = Mockito.mock(ExpressionList.class);
@@ -199,7 +200,7 @@ class TaskRepositoryEbeanTest {
   }
 
   @Test
-  void givenAUserIdAPriorityTheGetTasksShouldReturnAListOfTasks() {
+  void givenAUserIdAPriorityHighTheGetTasksShouldReturnAListOfNotTrashedTasksWithHighPriority() {
     // Given
     Task taskMock = Mockito.mock(Task.class);
     ExpressionList<Task> partialQueryMock = Mockito.mock(ExpressionList.class);
@@ -225,12 +226,11 @@ class TaskRepositoryEbeanTest {
     Assertions.assertThat(openTasks).hasSize(1);
 
     Mockito.verify(partialQueryMock, Mockito.times(1)).eq("priority", Priority.HIGH);
-    Mockito.verify(partialQueryMock, Mockito.times(0))
-        .eq(Mockito.eq("status"), Mockito.anyString());
+    Mockito.verify(partialQueryMock, Mockito.times(1)).ne("status", Status.TRASH);
   }
 
   @Test
-  void givenAUserIdTheGetTasksShouldReturnAListOfOpenTasks() {
+  void givenAUserIdTheGetTasksShouldReturnAListOfANotTrashedTasks() {
     // Given
     Task taskMock = Mockito.mock(Task.class);
     ExpressionList<Task> partialQueryMock = Mockito.mock(ExpressionList.class);
@@ -258,12 +258,11 @@ class TaskRepositoryEbeanTest {
     Mockito.verify(partialQueryMock, Mockito.times(0))
         .eq(Mockito.eq("priority"), Mockito.anyString());
 
-    Mockito.verify(partialQueryMock, Mockito.times(0))
-        .eq(Mockito.eq("status"), Mockito.anyString());
+    Mockito.verify(partialQueryMock, Mockito.times(1)).ne("status", Status.TRASH);
   }
 
   @Test
-  void givenATaskIdAndAUserIdTheGetTaskShouldReturnTheRequestedTask() {
+  void givenAnIdOfANotTrashedTaskAndAUserIdTheGetTaskShouldReturnTheRequestedTask() {
     // Given
     Mockito.when(
             ebeanDatabaseMock
@@ -271,6 +270,7 @@ class TaskRepositoryEbeanTest {
                 .where()
                 .idEq(UUID.fromString("6d162bee-3186-0000-bf31-59746a41600e"))
                 .eq("user_id", "6d162bee-3186-1111-bf31-59746a41600e")
+                .ne("status", Status.TRASH)
                 .findOneOrEmpty())
         .thenReturn(Optional.of(Mockito.mock(Task.class)));
 
@@ -293,6 +293,7 @@ class TaskRepositoryEbeanTest {
                 .where()
                 .idEq(UUID.fromString("00000000-3186-0000-bf31-59746a41600e"))
                 .eq("user_id", "6d162bee-3186-1111-bf31-59746a41600e")
+                .ne("status", Status.TRASH)
                 .findOneOrEmpty())
         .thenReturn(Optional.empty());
 
@@ -307,7 +308,7 @@ class TaskRepositoryEbeanTest {
   }
 
   @Test
-  void givenATaskIdAndADifferentUserIdTheGetTaskShouldReturnAnOptionalEmpty() {
+  void givenAnIdOfANotTrashedTaskAndADifferentUserIdTheGetTaskShouldReturnAnOptionalEmpty() {
     // Given
     Mockito.when(
             ebeanDatabaseMock
@@ -315,6 +316,7 @@ class TaskRepositoryEbeanTest {
                 .where()
                 .idEq(UUID.fromString("6d162bee-3186-0000-bf31-59746a41600e"))
                 .eq("user_id", "6d162bee-3186-1111-bf31-59746a41600e")
+                .ne("status", Status.TRASH)
                 .findOneOrEmpty())
         .thenReturn(Optional.of(Mockito.mock(Task.class)));
 


### PR DESCRIPTION
[feat: implement TrashTask API to mark a task as trashed](https://github.com/zextras/carbonio-tasks-ce/commit/b6d52dc29c1a3c95c6e9e7863933c9b557935f01)
- Added a new Status: `TRASH`. This one is not exposed in the schema but
  it is only needed to mark a task as trash in the database;
- Added a new datafetcher `trashTask` to update the status of the
  related task using the `Status#TRASH`;
- Created integration tests for this new API;
- Created unit tests for this new datafetcher;
- Improved the TestUtils adding a new method to transform the content of
  a GraphQL response data in a String.

---

[fix: update getTask and getTasks to filter out the trashed tasks](https://github.com/zextras/carbonio-tasks-ce/commit/1eb2c0d9d0a1f7117ec206af179682561156be82)
- This filter allows to never expose tasks in a trashed state.
- Added and fixed related ITs and UTs


refs: TSK-57