### PR TITLE
fix: make the service re-throws runtime exception in the Boot class

### DIFF
--- a/boot/src/main/java/com/zextras/carbonio/tasks/Boot.java
+++ b/boot/src/main/java/com/zextras/carbonio/tasks/Boot.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
 public class Boot {
   private static final Logger rootLogger = (Logger) LoggerFactory.getLogger("root");
 
-  public static void main(String[] args) {
+  public static void main(String[] args) throws Exception {
     // Set configuration level
     String logLevel = System.getProperty("TASKS_LOG_LEVEL");
     rootLogger.setLevel(logLevel == null ? Level.INFO : Level.toLevel(logLevel));
@@ -27,6 +27,7 @@ public class Boot {
       injector.getInstance(JettyServer.class).start();
     } catch (Exception exception) {
       rootLogger.error("Service stopped unexpectedly: ", exception);
+      throw exception;
     }
   }
 }


### PR DESCRIPTION
Updated the main() to re-throws every Runtime exception catched. It allows the systemd unit to be aware of the failing execution and to restart the service.

Refs: TSK-63