### PR TITLE
ci: add timestamp in the artifact pkgrel

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,8 +90,9 @@ pipeline {
                     }
                     steps {
                         sh'''
+                            export TIMESTAMP=$(date +%s)
                             export GIT_COMMIT_SHORT=$(git rev-parse HEAD | head -c 8)
-                            sed -i "s/pkgrel=\\"SNAPSHOT\\"/pkgrel=\\"$GIT_COMMIT_SHORT\\"/" ./package/PKGBUILD
+                            sed -i "s/pkgrel=\\"SNAPSHOT\\"/pkgrel=\\"$TIMESTAMP+$GIT_COMMIT_SHORT\\"/" ./package/PKGBUILD
                         '''
                     }
                 }

--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -24,7 +24,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.tasks</groupId>
     <artifactId>carbonio-tasks-ce</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.2.2-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -24,7 +24,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.tasks</groupId>
     <artifactId>carbonio-tasks-ce</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.2.2-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 pkgname="carbonio-tasks-ce"
-pkgver="0.2.1"
+pkgver="0.2.2"
 pkgrel="SNAPSHOT"
 pkgdesc="Carbonio Tasks"
 maintainer="Zextras <packages@zextras.com>"

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
   <groupId>com.zextras.carbonio.tasks</groupId>
   <artifactId>carbonio-tasks-ce</artifactId>
-  <version>0.2.1-SNAPSHOT</version>
+  <version>0.2.2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>carbonio-tasks-ce</name>


### PR DESCRIPTION
- Added the timestamp in the pkgrel so it can be used together with the git commit hash to replace the `SNAPSHOT` value and avoid to overwrite artifacts in the artifactory `develop` repository each time a new PR is merged.
- Bumped version to `SNAPSHOT`