### PR TITLE
build(deps): update all dependencies/plugins

### DIFF
--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -24,7 +24,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.tasks</groupId>
     <artifactId>carbonio-tasks-ce</artifactId>
-    <version>0.4.1-1</version>
+    <version>0.4.2-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -24,7 +24,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.tasks</groupId>
     <artifactId>carbonio-tasks-ce</artifactId>
-    <version>0.4.1-1</version>
+    <version>0.4.2-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 pkgname="carbonio-tasks-ce"
-pkgver="0.4.1"
-pkgrel="1"
+pkgver="0.4.2"
+pkgrel="SNAPSHOT"
 pkgdesc="Carbonio Tasks"
 maintainer="Zextras <packages@zextras.com>"
 arch=('x86_64')

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
   <groupId>com.zextras.carbonio.tasks</groupId>
   <artifactId>carbonio-tasks-ce</artifactId>
-  <version>0.4.1-1</version>
+  <version>0.4.2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>carbonio-tasks-ce</name>
@@ -49,7 +49,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <mockito.version>5.13.0</mockito.version>
     <postgresql.version>42.7.4</postgresql.version>
     <testcontainers.version>1.20.1</testcontainers.version>
-    <resteasy.version>6.2.10.Final</resteasy.version>
+    <resteasy.version>6.2.7.Final</resteasy.version>
     <resteasy-guice.version>6.2.7-alpha</resteasy-guice.version>
     <flyway-database-postgresql.version>10.17.3</flyway-database-postgresql.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,33 +33,33 @@ SPDX-License-Identifier: AGPL-3.0-only
 
   <properties>
     <!-- Dependencies -->
-    <assertj.version>3.25.3</assertj.version>
+    <assertj.version>3.26.3</assertj.version>
     <apache-httpclient.version>5.3.1</apache-httpclient.version>
     <carbonio-user-management-sdk.version>0.5.3</carbonio-user-management-sdk.version>
-    <ebean.version>15.0.1</ebean.version>
+    <ebean.version>15.5.1</ebean.version>
     <graphql-java-servlet.version>15.2.0</graphql-java-servlet.version>
     <guice.version>7.0.0</guice.version>
     <hikaricp.version>5.1.0</hikaricp.version>
-    <jakarta-servlet-api.version>6.0.0</jakarta-servlet-api.version>
-    <jetty.version>12.0.7</jetty.version>
-    <jsonassert.version>1.5.1</jsonassert.version>
-    <junit5.version>5.10.2</junit5.version>
-    <logback-classic.version>1.5.3</logback-classic.version>
+    <jakarta-servlet-api.version>6.1.0</jakarta-servlet-api.version>
+    <jetty.version>12.0.12</jetty.version>
+    <jsonassert.version>1.5.3</jsonassert.version>
+    <junit5.version>5.11.0</junit5.version>
+    <logback-classic.version>1.5.7</logback-classic.version>
     <mock-server.version>5.15.0</mock-server.version>
-    <mockito.version>5.11.0</mockito.version>
-    <postgresql.version>42.7.2</postgresql.version>
-    <testcontainers.version>1.19.7</testcontainers.version>
-    <resteasy.version>6.2.7.Final</resteasy.version>
+    <mockito.version>5.13.0</mockito.version>
+    <postgresql.version>42.7.4</postgresql.version>
+    <testcontainers.version>1.20.1</testcontainers.version>
+    <resteasy.version>6.2.10.Final</resteasy.version>
     <resteasy-guice.version>6.2.7-alpha</resteasy-guice.version>
-    <flyway-database-postgresql.version>10.9.1</flyway-database-postgresql.version>
+    <flyway-database-postgresql.version>10.17.3</flyway-database-postgresql.version>
 
     <!-- Plugins -->
-    <build-helper-maven.version>3.4.0</build-helper-maven.version>
-    <maven-shade.version>3.5.2</maven-shade.version>
-    <maven-compiler.version>3.12.0</maven-compiler.version>
-    <maven-failsafe.version>3.2.5</maven-failsafe.version>
-    <maven-jacoco.version>0.8.11</maven-jacoco.version>
-    <maven-surfire.version>3.2.3</maven-surfire.version>
+    <build-helper-maven.version>3.6.0</build-helper-maven.version>
+    <maven-shade.version>3.6.0</maven-shade.version>
+    <maven-compiler.version>3.13.0</maven-compiler.version>
+    <maven-failsafe.version>3.5.0</maven-failsafe.version>
+    <maven-jacoco.version>0.8.12</maven-jacoco.version>
+    <maven-surfire.version>3.3.1</maven-surfire.version>
     <tiles-maven.version>2.40</tiles-maven.version>
 
     <!-- Other properties -->


### PR DESCRIPTION
Updated all dependencies to their last version:
- assertj: 3.25.3 -> 3.26.3
- ebean: 15.0.1 -> 15.5.1
- jakarta-servlet-api: 6.0.0 -> 6.1.0
- jetty: 12.0.7 -> 12.0.12
- jsonassert: 1.5.1 -> 1.5.3
- junit5: 5.10.2 -> 5.11.0
- logback-classic: 1.5.3 -> 1.5.7
- mockito: 5.11.0 -> 5.13.0
- postgresql: 42.7.2 -> 42.7.4
- testcontainers: 1.19.7 -> 1.20.1
- resteasy: 6.2.7.Final -> 6.2.10.Final
- flyway-database-postgresql: 10.9.1 -> 10.17.3

- build-helper-maven: 3.4.0 -> 3.6.0
- maven-shade: 3.5.2 -> 3.6.0
- maven-compiler: 3.12.0 -> 3.13.0
- maven-failsafe: 3.2.5 -> 3.5.0
- maven-jacoco: 0.8.11 -> 0.8.12
- maven-surfire: 3.2.3 -> 3.3.1

Refs: TSK-87