### PR TITLE
CO-2474: normalize hikari configuration

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/tasks/Constants.java
+++ b/core/src/main/java/com/zextras/carbonio/tasks/Constants.java
@@ -55,9 +55,9 @@ public final class Constants {
 
       public static final int MAX_POOL_SIZE = 10;
       public static final int MIN_IDLE_CONNECTIONS = 2;
-      public static final int IDLE_TIMEOUT = 2;
-      public static final int LEAK_DETECTION_THRESHOLD = 2;
-      public static final int MAX_LIFETIME = 2;
+      public static final int IDLE_TIMEOUT = 10_000;
+      public static final int LEAK_DETECTION_THRESHOLD = 5_000;
+      public static final int MAX_LIFETIME = 600_000;
 
       private Hikari() {}
     }

--- a/core/src/main/java/com/zextras/carbonio/tasks/Constants.java
+++ b/core/src/main/java/com/zextras/carbonio/tasks/Constants.java
@@ -55,6 +55,9 @@ public final class Constants {
 
       public static final int MAX_POOL_SIZE = 10;
       public static final int MIN_IDLE_CONNECTIONS = 2;
+      public static final int IDLE_TIMEOUT = 2;
+      public static final int LEAK_DETECTION_THRESHOLD = 2;
+      public static final int MAX_LIFETIME = 2;
 
       private Hikari() {}
     }
@@ -112,6 +115,9 @@ public final class Constants {
         public static final String DB_PASSWORD = "db-password";
         public static final String HIKARI_MAX_POOL_SIZE = "hikari-max-pool-size";
         public static final String HIKARI_MIN_IDLE_CONNECTIONS = "hikari-min-idle-connections";
+        public static final String HIKARI_IDLE_TIMEOUT = "hikari-idle-timeout";
+        public static final String HIKARI_LEAK_DETECTION_THRESHOLD = "hikari-leak-detection-threshold";
+        public static final String HIKARI_MAX_LIFETIME = "hikari-max-lifetime";
 
         private Key() {}
       }

--- a/core/src/main/java/com/zextras/carbonio/tasks/config/TasksConfig.java
+++ b/core/src/main/java/com/zextras/carbonio/tasks/config/TasksConfig.java
@@ -119,6 +119,21 @@ public class TasksConfig {
         .orElse(Hikari.MIN_IDLE_CONNECTIONS);
   }
 
+  public int getHikariIdleTimeout() {
+    return getConfInt(Key.HIKARI_IDLE_TIMEOUT)
+      .orElse(Hikari.IDLE_TIMEOUT);
+  }
+
+  public int getHikariLeakDetectionThreshold() {
+    return getConfInt(Key.HIKARI_LEAK_DETECTION_THRESHOLD)
+      .orElse(Hikari.LEAK_DETECTION_THRESHOLD);
+  }
+
+  public int getHikariMaxLifetime() {
+    return getConfInt(Key.HIKARI_MAX_LIFETIME)
+      .orElse(Hikari.MAX_LIFETIME);
+  }
+
   private static Optional<Integer> getConfInt(String key) {
     return getConfig(key)
       .map(Integer::parseInt);

--- a/core/src/main/java/com/zextras/carbonio/tasks/config/TasksConfig.java
+++ b/core/src/main/java/com/zextras/carbonio/tasks/config/TasksConfig.java
@@ -108,33 +108,33 @@ public class TasksConfig {
   }
 
   public int getHikariMaxPoolSize() {
-    return getConfInt(Key.HIKARI_MAX_POOL_SIZE)
+    return getConfigInt(Key.HIKARI_MAX_POOL_SIZE)
         .orElse(Hikari.MAX_POOL_SIZE);
   }
 
   public int getHikariMinIdleConnections() {
     int maxPoolSize = getHikariMaxPoolSize();
-    return getConfInt(Key.HIKARI_MIN_IDLE_CONNECTIONS)
+    return getConfigInt(Key.HIKARI_MIN_IDLE_CONNECTIONS)
         .map(minIdleConnections -> Math.min(minIdleConnections, maxPoolSize))
         .orElse(Hikari.MIN_IDLE_CONNECTIONS);
   }
 
   public int getHikariIdleTimeout() {
-    return getConfInt(Key.HIKARI_IDLE_TIMEOUT)
+    return getConfigInt(Key.HIKARI_IDLE_TIMEOUT)
       .orElse(Hikari.IDLE_TIMEOUT);
   }
 
   public int getHikariLeakDetectionThreshold() {
-    return getConfInt(Key.HIKARI_LEAK_DETECTION_THRESHOLD)
+    return getConfigInt(Key.HIKARI_LEAK_DETECTION_THRESHOLD)
       .orElse(Hikari.LEAK_DETECTION_THRESHOLD);
   }
 
   public int getHikariMaxLifetime() {
-    return getConfInt(Key.HIKARI_MAX_LIFETIME)
+    return getConfigInt(Key.HIKARI_MAX_LIFETIME)
       .orElse(Hikari.MAX_LIFETIME);
   }
 
-  private static Optional<Integer> getConfInt(String key) {
+  private static Optional<Integer> getConfigInt(String key) {
     return getConfig(key)
       .map(Integer::parseInt);
   }

--- a/core/src/main/java/com/zextras/carbonio/tasks/config/TasksConfig.java
+++ b/core/src/main/java/com/zextras/carbonio/tasks/config/TasksConfig.java
@@ -69,20 +69,17 @@ public class TasksConfig {
   }
 
   public String getDatabaseName() {
-    return ServiceDiscoverHttpClient.defaultURL(Tasks.SERVICE_NAME)
-        .getConfig(Key.DB_NAME)
+    return getConfig(Key.DB_NAME)
         .orElse(Database.DEFAULT_NAME);
   }
 
   public String getDatabaseUsername() {
-    return ServiceDiscoverHttpClient.defaultURL(Tasks.SERVICE_NAME)
-        .getConfig(Key.DB_USERNAME)
+    return getConfig(Key.DB_USERNAME)
         .orElse(Database.DEFAULT_USERNAME);
   }
 
   public String getDatabasePassword() {
-    return ServiceDiscoverHttpClient.defaultURL(Tasks.SERVICE_NAME)
-        .getConfig(Key.DB_PASSWORD)
+    return getConfig(Key.DB_PASSWORD)
         .orElse("");
   }
 
@@ -111,18 +108,24 @@ public class TasksConfig {
   }
 
   public int getHikariMaxPoolSize() {
-    return ServiceDiscoverHttpClient.defaultURL(Tasks.SERVICE_NAME)
-        .getConfig(Key.HIKARI_MAX_POOL_SIZE)
-        .map(Integer::parseInt)
+    return getConfInt(Key.HIKARI_MAX_POOL_SIZE)
         .orElse(Hikari.MAX_POOL_SIZE);
   }
 
   public int getHikariMinIdleConnections() {
     int maxPoolSize = getHikariMaxPoolSize();
-    return ServiceDiscoverHttpClient.defaultURL(Tasks.SERVICE_NAME)
-        .getConfig(Key.HIKARI_MIN_IDLE_CONNECTIONS)
-        .map(minIdleConnections ->
-            Math.min(Integer.parseInt(minIdleConnections), maxPoolSize))
+    return getConfInt(Key.HIKARI_MIN_IDLE_CONNECTIONS)
+        .map(minIdleConnections -> Math.min(minIdleConnections, maxPoolSize))
         .orElse(Hikari.MIN_IDLE_CONNECTIONS);
+  }
+
+  private static Optional<Integer> getConfInt(String key) {
+    return getConfig(key)
+      .map(Integer::parseInt);
+  }
+
+  private static Optional<String> getConfig(String key) {
+    return ServiceDiscoverHttpClient.defaultURL(Tasks.SERVICE_NAME)
+      .getConfig(key);
   }
 }

--- a/core/src/main/java/com/zextras/carbonio/tasks/config/TasksModule.java
+++ b/core/src/main/java/com/zextras/carbonio/tasks/config/TasksModule.java
@@ -89,9 +89,15 @@ public class TasksModule extends AbstractModule {
 
     int maximumPoolSize = config.getHikariMaxPoolSize();
     int minimumIdleConnections = config.getHikariMinIdleConnections();
+    int idleTimeout = config.getHikariIdleTimeout();
+    int leakDetectionThreshold = config.getHikariLeakDetectionThreshold();
+    int maxLifetime = config.getHikariMaxLifetime();
 
     logger.info("Hikari: maximum pool size: {}", maximumPoolSize);
     logger.info("Hikari: minimum idle connections: {}", minimumIdleConnections);
+    logger.info("Hikari: idle timeout: {}", idleTimeout);
+    logger.info("Hikari: leak detection threshold: {}", leakDetectionThreshold);
+    logger.info("Hikari: max lifetime: {}", maxLifetime);
 
     Properties dataSourceProperties = new Properties();
     dataSourceProperties.setProperty("sslmode", "disable");
@@ -104,12 +110,11 @@ public class TasksModule extends AbstractModule {
     dataSource.setPassword(config.getDatabasePassword());
     dataSource.setMaximumPoolSize(maximumPoolSize);
     dataSource.setMinimumIdle(minimumIdleConnections);
+    dataSource.setIdleTimeout(idleTimeout);
+    dataSource.setLeakDetectionThreshold(leakDetectionThreshold);
+    dataSource.setMaxLifetime(maxLifetime);
     dataSource.setDataSourceProperties(dataSourceProperties);
-    /*
-config.setIdleTimeout(HIKARI_IDLE_TIMEOUT.orElse(10000));
-config.setLeakDetectionThreshold(HIKARI_LEAK_DETECTION_THRESHOLD.orElse(5000));
-config.setMaxLifetime(HIKARI_MAX_LIFETIME.orElse(600000));
-     */
+
     return dataSource;
   }
 

--- a/core/src/main/java/com/zextras/carbonio/tasks/config/TasksModule.java
+++ b/core/src/main/java/com/zextras/carbonio/tasks/config/TasksModule.java
@@ -32,7 +32,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Clock;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
 public class TasksModule extends AbstractModule {
 
@@ -91,14 +95,26 @@ public class TasksModule extends AbstractModule {
 
     Properties dataSourceProperties = new Properties();
     dataSourceProperties.setProperty("sslmode", "disable");
+    dataSourceProperties.setProperty("ApplicationName", "tasks");
 
     HikariDataSource dataSource = new HikariDataSource();
     dataSource.setJdbcUrl(jdbcPostgresUrl);
+    dataSource.setPoolName("tasks-db-pool");
     dataSource.setUsername(config.getDatabaseUsername());
     dataSource.setPassword(config.getDatabasePassword());
     dataSource.setMaximumPoolSize(maximumPoolSize);
     dataSource.setMinimumIdle(minimumIdleConnections);
     dataSource.setDataSourceProperties(dataSourceProperties);
+    /*
+config.setIdleTimeout(HIKARI_IDLE_TIMEOUT.orElse(10000));
+config.setLeakDetectionThreshold(HIKARI_LEAK_DETECTION_THRESHOLD.orElse(5000));
+config.setMaxLifetime(HIKARI_MAX_LIFETIME.orElse(600000));
+
+Properties dataSourceProperties = new Properties();
+dataSourceProperties.setProperty("sslmode", "disable");
+dataSourceProperties.setProperty("ApplicationName", "ws-collaboration");
+dataSource.setDataSourceProperties(properties);
+     */
     return dataSource;
   }
 

--- a/core/src/main/java/com/zextras/carbonio/tasks/config/TasksModule.java
+++ b/core/src/main/java/com/zextras/carbonio/tasks/config/TasksModule.java
@@ -109,11 +109,6 @@ public class TasksModule extends AbstractModule {
 config.setIdleTimeout(HIKARI_IDLE_TIMEOUT.orElse(10000));
 config.setLeakDetectionThreshold(HIKARI_LEAK_DETECTION_THRESHOLD.orElse(5000));
 config.setMaxLifetime(HIKARI_MAX_LIFETIME.orElse(600000));
-
-Properties dataSourceProperties = new Properties();
-dataSourceProperties.setProperty("sslmode", "disable");
-dataSourceProperties.setProperty("ApplicationName", "ws-collaboration");
-dataSource.setDataSourceProperties(properties);
      */
     return dataSource;
   }

--- a/core/src/test/java-ut/com/zextras/carbonio/tasks/config/TaskConfigTest.java
+++ b/core/src/test/java-ut/com/zextras/carbonio/tasks/config/TaskConfigTest.java
@@ -62,8 +62,9 @@ class TaskConfigTest {
     Assertions.assertThat(dataSource.getPassword()).isEqualTo("fake-db-password");
 
     Properties dataSourceProperties = dataSource.getDataSourceProperties();
-    Assertions.assertThat(dataSourceProperties).hasSize(1);
+    Assertions.assertThat(dataSourceProperties).hasSize(2);
     Assertions.assertThat(dataSourceProperties.getProperty("sslmode")).isEqualTo("disable");
+    Assertions.assertThat(dataSourceProperties.getProperty("ApplicationName")).isEqualTo("tasks");
 
     serviceDiscoverMock.verify(
         HttpRequest.request()
@@ -99,8 +100,9 @@ class TaskConfigTest {
     Assertions.assertThat(dataSource.getPassword()).isEmpty();
 
     Properties dataSourceProperties = dataSource.getDataSourceProperties();
-    Assertions.assertThat(dataSourceProperties).hasSize(1);
+    Assertions.assertThat(dataSourceProperties).hasSize(2);
     Assertions.assertThat(dataSourceProperties.getProperty("sslmode")).isEqualTo("disable");
+    Assertions.assertThat(dataSourceProperties.getProperty("ApplicationName")).isEqualTo("tasks");
   }
 
   @Test
@@ -181,8 +183,9 @@ class TaskConfigTest {
     Assertions.assertThat(dataSource.getPassword()).isEqualTo("fake-db-password");
 
     Properties dataSourceProperties = dataSource.getDataSourceProperties();
-    Assertions.assertThat(dataSourceProperties).hasSize(1);
+    Assertions.assertThat(dataSourceProperties).hasSize(2);
     Assertions.assertThat(dataSourceProperties.getProperty("sslmode")).isEqualTo("disable");
+    Assertions.assertThat(dataSourceProperties.getProperty("ApplicationName")).isEqualTo("tasks");
 
     serviceDiscoverMock.verify(
         HttpRequest.request()
@@ -227,8 +230,9 @@ class TaskConfigTest {
     Assertions.assertThat(dataSource.getPassword()).isEmpty();
 
     Properties dataSourceProperties = dataSource.getDataSourceProperties();
-    Assertions.assertThat(dataSourceProperties).hasSize(1);
+    Assertions.assertThat(dataSourceProperties).hasSize(2);
     Assertions.assertThat(dataSourceProperties.getProperty("sslmode")).isEqualTo("disable");
+    Assertions.assertThat(dataSourceProperties.getProperty("ApplicationName")).isEqualTo("tasks");
   }
 
   private void createServiceDiscoverMock() {


### PR DESCRIPTION
Each Carbonio component uses a different HikariCP configuration, which could lead to inconsistent behavior, especially under pressure.

This PR adds the missing properties and a few small refactoring touches.