### PR TITLE
chore: [CO-2850] add service-discover properties

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/tasks/Constants.java
+++ b/core/src/main/java/com/zextras/carbonio/tasks/Constants.java
@@ -4,6 +4,8 @@
 
 package com.zextras.carbonio.tasks;
 
+import com.zextras.carbonio.tasks.Constants.ServiceDiscover;
+
 public final class Constants {
   private Constants() {}
 
@@ -71,6 +73,15 @@ public final class Constants {
       public static final Integer DEFAULT_PORT = 20001;
 
       private UserManagement() {}
+    }
+
+    public static final class ServiceDiscover {
+      private ServiceDiscover() {
+      }
+      public static final String HOST_PROPERTY = "carbonio.service-discover.host";
+      public static final String PORT_PROPERTY = "carbonio.service-discover.port";
+      public static final String DEFAULT_HOST = "localhost";
+      public static final Integer DEFAULT_PORT = 8500;
     }
   }
 

--- a/core/src/main/java/com/zextras/carbonio/tasks/config/TasksConfig.java
+++ b/core/src/main/java/com/zextras/carbonio/tasks/config/TasksConfig.java
@@ -7,6 +7,7 @@ package com.zextras.carbonio.tasks.config;
 import com.zextras.carbonio.tasks.Constants;
 import com.zextras.carbonio.tasks.Constants.Config.Database;
 import com.zextras.carbonio.tasks.Constants.Config.Hikari;
+import com.zextras.carbonio.tasks.Constants.Config.ServiceDiscover;
 import com.zextras.carbonio.tasks.Constants.Tasks;
 import com.zextras.carbonio.tasks.Constants.ServiceDiscover.Config.Key;
 import com.zextras.carbonio.tasks.clients.ServiceDiscoverHttpClient;
@@ -26,29 +27,29 @@ public class TasksConfig {
 
   private final Properties properties;
 
-  public TasksConfig() {
-    properties = new Properties();
+  private TasksConfig(Properties properties) {
+    this.properties = properties;
   }
 
-  // Load config from files or system properties.
-  public void loadConfig() throws IOException {
+  public static TasksConfig getConfig() {
+    final Properties properties = new Properties();
     loadFromEtc() // the official way
-      .ifPresent(config -> {
-        try {
-          properties.load(config);
-        } catch (IOException e) {
-          logger.warn("Error loading configuration file: {}", e.getMessage());
-        }
-      });
-
-    properties.putAll(System.getProperties()); // the dev way, overriding existing properties
+        .ifPresent(config -> {
+          try {
+            properties.load(config);
+          } catch (IOException e) {
+            logger.warn("Error loading configuration file: {}", e.getMessage());
+          }
+        });
+    properties.putAll(System.getProperties());
+    return new TasksConfig(properties);
   }
 
-  private Optional<InputStream> loadFromEtc() {
+  private static Optional<InputStream> loadFromEtc() {
     return loadFile("/etc/carbonio/tasks/config.properties");
   }
 
-  private Optional<InputStream> loadFile(String path) {
+  private static Optional<InputStream> loadFile(String path) {
     try {
       return Optional.of(new FileInputStream(path));
     } catch (FileNotFoundException e) {
@@ -134,13 +135,20 @@ public class TasksConfig {
       .orElse(Hikari.MAX_LIFETIME);
   }
 
-  private static Optional<Integer> getConfigInt(String key) {
+  private Optional<Integer> getConfigInt(String key) {
     return getConfig(key)
       .map(Integer::parseInt);
   }
 
-  private static Optional<String> getConfig(String key) {
-    return ServiceDiscoverHttpClient.defaultURL(Tasks.SERVICE_NAME)
+  public String getServiceDiscoverEndpoint() {
+    return "http://" + properties.getProperty(
+        ServiceDiscover.HOST_PROPERTY,
+        ServiceDiscover.DEFAULT_HOST) + ":" + properties.getProperty(ServiceDiscover.PORT_PROPERTY,
+				String.valueOf(ServiceDiscover.DEFAULT_PORT));
+  }
+
+  private Optional<String> getConfig(String key) {
+    return ServiceDiscoverHttpClient.atURL(this.getServiceDiscoverEndpoint(), Tasks.SERVICE_NAME)
       .getConfig(key);
   }
 }

--- a/core/src/main/java/com/zextras/carbonio/tasks/config/TasksModule.java
+++ b/core/src/main/java/com/zextras/carbonio/tasks/config/TasksModule.java
@@ -74,9 +74,7 @@ public class TasksModule extends AbstractModule {
   @Provides
   @Singleton
   public TasksConfig provideConfig() throws Exception {
-    final TasksConfig config = new TasksConfig();
-    config.loadConfig();
-    return config;
+    return TasksConfig.getConfig();
   }
 
   @Provides

--- a/core/src/test/java-ut/com/zextras/carbonio/tasks/config/TaskConfigTest.java
+++ b/core/src/test/java-ut/com/zextras/carbonio/tasks/config/TaskConfigTest.java
@@ -8,6 +8,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.zaxxer.hikari.HikariDataSource;
 import com.zextras.carbonio.tasks.Constants;
+import com.zextras.carbonio.tasks.Constants.Config.ServiceDiscover;
 import com.zextras.carbonio.tasks.dal.dao.Task;
 import io.ebean.config.DatabaseConfig;
 import java.util.Properties;
@@ -121,11 +122,41 @@ class TaskConfigTest {
   }
 
   @Test
+  void givenServiceDiscoverHostAndPortSystemPropertyTheTasksConfigShouldReturnThem() {
+    // Given
+    System.setProperty(ServiceDiscover.HOST_PROPERTY, "other-host");
+    System.setProperty(ServiceDiscover.PORT_PROPERTY, "10000");
+
+    // When
+    Injector injector = Guice.createInjector(new TasksModule());
+    TasksConfig tasksConfig = injector.getInstance(TasksConfig.class);
+
+    // Then
+    Assertions.assertThat(tasksConfig.getServiceDiscoverEndpoint())
+        .isEqualTo("http://other-host:10000");
+  }
+
+  @Test
+  void givenServiceDiscoverHostAndPortSystemPropertyEmptyTheTasksConfigShouldReturnDefaultValues() {
+    // Given
+    System.clearProperty(ServiceDiscover.HOST_PROPERTY);
+    System.clearProperty(ServiceDiscover.PORT_PROPERTY);
+
+    // When
+    Injector injector = Guice.createInjector(new TasksModule());
+    TasksConfig tasksConfig = injector.getInstance(TasksConfig.class);
+
+    // Then
+    Assertions.assertThat(tasksConfig.getServiceDiscoverEndpoint())
+        .isEqualTo("http://localhost:8500");
+  }
+
+  @Test
   void havingAnAvailableServiceDiscoverTheTasksConfigShouldReturnADatabaseName() {
     // Given
     createServiceDiscoverMock();
     // When
-    String databaseName = new TasksConfig().getDatabaseName();
+    String databaseName = TasksConfig.getConfig().getDatabaseName();
 
     // Then
     Assertions.assertThat(databaseName).isEqualTo("fake-db-name");
@@ -152,7 +183,7 @@ class TaskConfigTest {
   @Test
   void withoutAnAvailableServiceDiscoverTheTasksConfigShouldReturnADatabaseName() {
     // Given & When
-    String databaseName = new TasksConfig().getDatabaseName();
+    String databaseName = TasksConfig.getConfig().getDatabaseName();
 
     // Then
     Assertions.assertThat(databaseName).isEqualTo("carbonio-tasks-db");

--- a/core/src/test/java-ut/com/zextras/carbonio/tasks/config/TaskConfigTest.java
+++ b/core/src/test/java-ut/com/zextras/carbonio/tasks/config/TaskConfigTest.java
@@ -44,6 +44,8 @@ class TaskConfigTest {
 
   @BeforeEach
   void setUp() {
+    System.clearProperty(ServiceDiscover.HOST_PROPERTY);
+    System.clearProperty(ServiceDiscover.PORT_PROPERTY);
     serviceDiscoverMock.reset();
   }
 
@@ -138,9 +140,6 @@ class TaskConfigTest {
 
   @Test
   void givenServiceDiscoverHostAndPortSystemPropertyEmptyTheTasksConfigShouldReturnDefaultValues() {
-    // Given
-    System.clearProperty(ServiceDiscover.HOST_PROPERTY);
-    System.clearProperty(ServiceDiscover.PORT_PROPERTY);
 
     // When
     Injector injector = Guice.createInjector(new TasksModule());

--- a/docker/minimal/carbonio-tasks/Dockerfile
+++ b/docker/minimal/carbonio-tasks/Dockerfile
@@ -5,19 +5,6 @@ WORKDIR /app
 RUN mkdir -p /etc/carbonio/tasks
 
 COPY ../../boot/target/carbonio-tasks-*-jar-with-dependencies.jar .
+COPY docker/minimal/carbonio-tasks/entrypoint.sh entrypoint.sh
 
-CMD sh -c 'echo "\n\
-carbonio.tasks.host=${CARBONIO_TASKS_HOST}\n\
-carbonio.tasks.port=${CARBONIO_TASKS_PORT}\n\
-\n\
-carbonio.postgres.host=${CARBONIO_POSTGRES_HOST}\n\
-carbonio.postgres.port=${CARBONIO_POSTGRES_PORT}\n\
-\n\
-carbonio.user-management.host=${CARBONIO_USER_MANAGEMENT_HOST}\n\
-carbonio.user-management.port=${CARBONIO_USER_MANAGEMENT_PORT}" > /etc/carbonio/tasks/config.properties && \
-JAR=$(ls carbonio-tasks-*-jar-with-dependencies.jar | head -n 1) && \
-java -Djava.net.preferIPv4Stack=true \
-     -Xms1024m \
-     -Xmx2048m \
-     -DTASKS_LOG_LEVEL=info \
-     -jar "$JAR"'
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/docker/minimal/carbonio-tasks/entrypoint.sh
+++ b/docker/minimal/carbonio-tasks/entrypoint.sh
@@ -1,18 +1,25 @@
 #!/bin/sh
 
-cat > /etc/carbonio/tasks/config.properties <<EOF
-carbonio.tasks.host=${CARBONIO_TASKS_HOST}
-carbonio.tasks.port=${CARBONIO_TASKS_PORT}
+echo "" > /etc/carbonio/files/config.properties
 
-carbonio.postgres.host=${CARBONIO_POSTGRES_HOST}
-carbonio.postgres.port=${CARBONIO_POSTGRES_PORT}
+addEnvToProperties() {
+  if [ -n "$2" ];
+  then echo "$1=$2" >> /etc/carbonio/files/config.properties;
+  else echo "$1 is not set. Skipping it.";
+  fi
+}
 
-carbonio.user-management.host=${CARBONIO_USER_MANAGEMENT_HOST}
-carbonio.user-management.port=${CARBONIO_USER_MANAGEMENT_PORT}
+addEnvToProperties "carbonio.tasks.host" "${CARBONIO_TASKS_HOST}"
+addEnvToProperties "carbonio.tasks.port" "${CARBONIO_TASKS_PORT}"
 
-carbonio.service-discover.host=${CARBONIO_SERVICE_DISCOVER_HOST}
-carbonio.service-discover.port=${CARBONIO_SERVICE_DISCOVER_PORT}
-EOF
+addEnvToProperties "carbonio.postgres.host" "${CARBONIO_POSTGRES_HOST}"
+addEnvToProperties "carbonio.postgres.port" "${CARBONIO_POSTGRES_PORT}"
+
+addEnvToProperties "carbonio.user-management.host" "${CARBONIO_USER_MANAGEMENT_HOST}"
+addEnvToProperties "carbonio.user-management.port" "${CARBONIO_USER_MANAGEMENT_PORT}"
+
+addEnvToProperties "carbonio.service-discover.host" "${CARBONIO_SERVICE_DISCOVER_HOST}"
+addEnvToProperties "carbonio.service-discover.port" "${CARBONIO_SERVICE_DISCOVER_PORT}"
 
 JAR=$(ls /app/carbonio-tasks-*-jar-with-dependencies.jar | head -n 1)
 

--- a/docker/minimal/carbonio-tasks/entrypoint.sh
+++ b/docker/minimal/carbonio-tasks/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+cat > /etc/carbonio/tasks/config.properties <<EOF
+carbonio.tasks.host=${CARBONIO_TASKS_HOST}
+carbonio.tasks.port=${CARBONIO_TASKS_PORT}
+
+carbonio.postgres.host=${CARBONIO_POSTGRES_HOST}
+carbonio.postgres.port=${CARBONIO_POSTGRES_PORT}
+
+carbonio.user-management.host=${CARBONIO_USER_MANAGEMENT_HOST}
+carbonio.user-management.port=${CARBONIO_USER_MANAGEMENT_PORT}
+
+carbonio.service-discover.host=${CARBONIO_SERVICE_DISCOVER_HOST}
+carbonio.service-discover.port=${CARBONIO_SERVICE_DISCOVER_PORT}
+EOF
+
+JAR=$(ls /app/carbonio-tasks-*-jar-with-dependencies.jar | head -n 1)
+
+exec java -Djava.net.preferIPv4Stack=true \
+          -Xms1024m \
+          -Xmx2048m \
+          -DTASKS_LOG_LEVEL=info \
+          -jar "$JAR"

--- a/docker/minimal/carbonio-tasks/entrypoint.sh
+++ b/docker/minimal/carbonio-tasks/entrypoint.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-echo "" > /etc/carbonio/files/config.properties
+echo "" > /etc/carbonio/tasks/config.properties
 
 addEnvToProperties() {
   if [ -n "$2" ];
-  then echo "$1=$2" >> /etc/carbonio/files/config.properties;
+  then echo "$1=$2" >> /etc/carbonio/tasks/config.properties;
   else echo "$1 is not set. Skipping it.";
   fi
 }
@@ -20,6 +20,7 @@ addEnvToProperties "carbonio.user-management.port" "${CARBONIO_USER_MANAGEMENT_P
 
 addEnvToProperties "carbonio.service-discover.host" "${CARBONIO_SERVICE_DISCOVER_HOST}"
 addEnvToProperties "carbonio.service-discover.port" "${CARBONIO_SERVICE_DISCOVER_PORT}"
+
 
 JAR=$(ls /app/carbonio-tasks-*-jar-with-dependencies.jar | head -n 1)
 


### PR DESCRIPTION
Tested docker build and container with custom service discover properties.
Tested also that if no env is defined for service discover, then it connects to localhost:8500 (tested on current compose implementation)