### PR TITLE
build: upgrade JDK from 17 to 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,7 +75,7 @@ pipeline {
                     if (env.TAG_NAME) {
                         profile = '-P prod'
                     }
-                    container('jdk-17') {
+                    container('jdk-21') {
                         sh """
                             mvn -B clean package ${profile}
                             cp boot/target/carbonio-tasks-*-jar-with-dependencies.jar package/carbonio-tasks.jar
@@ -90,7 +90,7 @@ pipeline {
                 expression { params.SKIP_TESTS == false }
             }
             steps {
-                container('jdk-17') {
+                container('jdk-21') {
                     sh 'mvn -B verify -P run-unit-tests'
                 }
             }
@@ -101,7 +101,7 @@ pipeline {
                 expression { params.SKIP_TESTS == false }
             }
             steps {
-                container('jdk-17') {
+                container('jdk-21') {
                     sh 'mvn -B verify -P run-integration-tests'
                 }
             }
@@ -112,7 +112,7 @@ pipeline {
                 expression { params.SKIP_CHECKS == false }
             }
             steps {
-                container('jdk-17') {
+                container('jdk-21') {
                     sh 'mvn -B verify -P generate-jacoco-full-report'
                     recordCoverage(
                         tools: [[parser: 'JACOCO']],
@@ -133,7 +133,7 @@ pipeline {
                }
             }
             steps {
-                container('jdk-17') {
+                container('jdk-21') {
                     withSonarQubeEnv(credentialsId: 'sonarqube-user-token', installationName: 'SonarQube instance') {
                         sh 'mvn -B sonar:sonar'
                     }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -263,10 +263,16 @@ SPDX-License-Identifier: AGPL-3.0-only
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${maven-surfire.version}</version>
-        <configuration>
-          <skipTests>${skip.unit.tests}</skipTests>
-        </configuration>
+        <version>${maven-surefire.version}</version>
+          <configuration>
+              <skipTests>${skip.unit.tests}</skipTests>
+              <argLine>
+                  -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar
+              </argLine>
+              <systemPropertyVariables>
+                  <slf4j.provider>ch.qos.logback.classic.spi.LogbackServiceProvider</slf4j.provider>
+              </systemPropertyVariables>
+          </configuration>
       </plugin>
 
       <plugin>

--- a/core/src/test/java-it/com/zextras/carbonio/tasks/Simulator.java
+++ b/core/src/test/java-it/com/zextras/carbonio/tasks/Simulator.java
@@ -64,7 +64,7 @@ public class Simulator implements AutoCloseable {
   private Simulator startDatabaseContainer() {
 
     if (postgreSQLContainer == null) {
-      postgreSQLContainer = new PostgreSQLContainer<>("postgres:12.14");
+      postgreSQLContainer = new PostgreSQLContainer<>("postgres:16");
     }
 
     postgreSQLContainer.start();
@@ -154,7 +154,8 @@ public class Simulator implements AutoCloseable {
   public Simulator startUserManagement() {
 
     startMockServer();
-    userManagementMock = new MockServerClient(UserManagement.DEFAULT_HOST, UserManagement.DEFAULT_PORT);
+    userManagementMock = new MockServerClient("localhost", UserManagement.DEFAULT_PORT);
+    System.setProperty(UserManagement.HOST_PROPERTY, "localhost");
     return this;
   }
 

--- a/docker/minimal/carbonio-tasks/Dockerfile
+++ b/docker/minimal/carbonio-tasks/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jdk-alpine
+FROM eclipse-temurin:21-jdk-alpine
 
 WORKDIR /app
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,9 @@ SPDX-License-Identifier: AGPL-3.0-only
     <mock-server.version>5.15.0</mock-server.version>
     <mockito.version>5.20.0</mockito.version>
     <postgresql.version>42.7.4</postgresql.version>
-    <testcontainers.version>1.20.1</testcontainers.version>
+    <testcontainers.version>2.0.2</testcontainers.version>
+    <testcontainers.postgresql.version>1.21.3</testcontainers.postgresql.version>
+    <testcontainers.junit.jupiter.version>1.21.3</testcontainers.junit.jupiter.version>
     <resteasy.version>6.2.7.Final</resteasy.version>
     <resteasy-guice.version>6.2.7-alpha</resteasy-guice.version>
     <flyway-database-postgresql.version>11.8.1</flyway-database-postgresql.version>
@@ -244,14 +246,14 @@ SPDX-License-Identifier: AGPL-3.0-only
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>junit-jupiter</artifactId>
-        <version>${testcontainers.version}</version>
+        <version>${testcontainers.junit.jupiter.version}</version>
         <scope>test</scope>
       </dependency>
 
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>postgresql</artifactId>
-        <version>${testcontainers.version}</version>
+        <version>${testcontainers.postgresql.version}</version>
         <scope>test</scope>
       </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <junit5.version>5.11.0</junit5.version>
     <logback-classic.version>1.5.7</logback-classic.version>
     <mock-server.version>5.15.0</mock-server.version>
-    <mockito.version>5.13.0</mockito.version>
+    <mockito.version>5.20.0</mockito.version>
     <postgresql.version>42.7.4</postgresql.version>
     <testcontainers.version>1.20.1</testcontainers.version>
     <resteasy.version>6.2.7.Final</resteasy.version>
@@ -59,13 +59,13 @@ SPDX-License-Identifier: AGPL-3.0-only
     <maven-compiler.version>3.13.0</maven-compiler.version>
     <maven-failsafe.version>3.5.0</maven-failsafe.version>
     <maven-jacoco.version>0.8.12</maven-jacoco.version>
-    <maven-surfire.version>3.3.1</maven-surfire.version>
+    <maven-surefire.version>3.5.4</maven-surefire.version>
     <tiles-maven.version>2.40</tiles-maven.version>
 
     <!-- Other properties -->
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
-    <java-compiler.version>17</java-compiler.version>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
+    <java-compiler.version>21</java-compiler.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <sonar.coverage.jacoco.xmlReportPaths>
       ../core/target/jacoco-full-report/jacoco.xml

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,6 @@ SPDX-License-Identifier: AGPL-3.0-only
         <version>${jakarta-servlet-api.version}</version>
       </dependency>
 
-
       <!-- GraphQL servlet -->
       <dependency>
         <groupId>com.graphql-java-kickstart</groupId>


### PR DESCRIPTION
- Upgrade mockito version from 5.13.0 to 5.20.0
- Upgrade maven-surefire-plugin version from 3.3.1 to 3.5.4
- Update Java version to 21 in pom.xml files
- Configure Mockito agent for JDK 21 compatibility
- Update maven-surefire-plugin configuration
- Set slf4j provider in the maven-surefire-plugin to solve warning in tests
- Set localhost as host for UserManagement in Simulator

ref: CO-2825