### PR TITLE
fix: add @Name annotations to preserve GraphQL type names

### DIFF
--- a/app/src/main/java/com/zextras/carbonio/tasks/graphql/types/NewTaskInput.java
+++ b/app/src/main/java/com/zextras/carbonio/tasks/graphql/types/NewTaskInput.java
@@ -6,8 +6,10 @@ package com.zextras.carbonio.tasks.graphql.types;
 
 import com.zextras.carbonio.tasks.dal.dao.Priority;
 import com.zextras.carbonio.tasks.dal.dao.Status;
+import org.eclipse.microprofile.graphql.Name;
 
 /** GraphQL input type for the {@code createTask} mutation. */
+@Name("NewTaskInput")
 public class NewTaskInput {
 
   private String title;

--- a/app/src/main/java/com/zextras/carbonio/tasks/graphql/types/TaskResponse.java
+++ b/app/src/main/java/com/zextras/carbonio/tasks/graphql/types/TaskResponse.java
@@ -7,12 +7,14 @@ package com.zextras.carbonio.tasks.graphql.types;
 import com.zextras.carbonio.tasks.dal.dao.Priority;
 import com.zextras.carbonio.tasks.dal.dao.Status;
 import org.eclipse.microprofile.graphql.Id;
+import org.eclipse.microprofile.graphql.Name;
 
 /**
  * GraphQL output type for a {@link com.zextras.carbonio.tasks.dal.dao.Task}.
  *
  * <p>Dates are represented as epoch milliseconds (Long) — SmallRye maps these to BigInteger.
  */
+@Name("Task")
 public class TaskResponse {
 
   @Id

--- a/app/src/main/java/com/zextras/carbonio/tasks/graphql/types/UpdateTaskInput.java
+++ b/app/src/main/java/com/zextras/carbonio/tasks/graphql/types/UpdateTaskInput.java
@@ -7,8 +7,10 @@ package com.zextras.carbonio.tasks.graphql.types;
 import com.zextras.carbonio.tasks.dal.dao.Priority;
 import com.zextras.carbonio.tasks.dal.dao.Status;
 import org.eclipse.microprofile.graphql.Id;
+import org.eclipse.microprofile.graphql.Name;
 
 /** GraphQL input type for the {@code updateTask} mutation. */
+@Name("UpdateTaskInput")
 public class UpdateTaskInput {
 
   @Id


### PR DESCRIPTION
## Summary
- SmallRye GraphQL auto-appends `Input` suffix to input type classes, causing `NewTaskInput` → `NewTaskInputInput` and `UpdateTaskInput` → `UpdateTaskInputInput`
- `TaskResponse` output type was not mapped to `Task` as expected by the client schema
- Added explicit `@Name` annotations on all three types to match the original GraphQL schema

## Test plan
- [x] Verified with local Docker build (native image) against carbonio-dockerization
- [x] Task creation works end-to-end through the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)