### PR TITLE
chore(deps): bump user-management SDK + protobuf fix

### DIFF
--- a/app/docs/schema.graphql
+++ b/app/docs/schema.graphql
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 type Query {
-  "Returns service metadata: name, version and flavour."
-  getServiceInfo: ServiceInfo
   "Returns all non-trashed tasks for the authenticated user, optionally filtered."
   findTasks(
   status: Status
@@ -12,18 +10,20 @@ type Query {
   "Returns a single task by its ID for the authenticated user."
   getTask(
   taskId: ID): Task
+  "Returns service metadata: name, version and flavour."
+  getServiceInfo: ServiceInfo
 }
 
 type Mutation {
   "Moves a task to the TRASH status, making it invisible to normal queries."
   trashTask(
   taskId: ID): ID
-  "Creates a new task for the authenticated user."
-  createTask(
-  newTask: NewTaskInput): Task
   "Updates an existing task. Only fields present in the input are modified."
   updateTask(
   updateTask: UpdateTaskInput): Task
+  "Creates a new task for the authenticated user."
+  createTask(
+  newTask: NewTaskInput): Task
 }
 
 type ServiceInfo {

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
   <properties>
     <!-- Dependencies -->
-    <carbonio-user-management-grpc-sdk.version>1.0.3-dev.20.719a98d8</carbonio-user-management-grpc-sdk.version>
+    <carbonio-user-management-grpc-sdk.version>1.0.3-dev.21.79fc3fa2</carbonio-user-management-grpc-sdk.version>
 
     <!-- Plugins -->
     <maven-compiler.version>3.13.0</maven-compiler.version>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
   <properties>
     <!-- Dependencies -->
-    <carbonio-user-management-grpc-sdk.version>1.0.3-dev.1.324e7740</carbonio-user-management-grpc-sdk.version>
+    <carbonio-user-management-grpc-sdk.version>1.0.3-dev.20.719a98d8</carbonio-user-management-grpc-sdk.version>
 
     <!-- Plugins -->
     <maven-compiler.version>3.13.0</maven-compiler.version>


### PR DESCRIPTION
## Summary
- Bumps `carbonio-user-management-grpc-sdk` to `1.0.3-dev.21.79fc3fa2`
- New SDK version includes protobuf-java 4.33.2 pin from `sdk-parent:1.8.2-1`

## Test plan
- [x] Jenkins build GREEN on `update-um`

🤖 Generated with [Claude Code](https://claude.com/claude-code)