### PR TITLE
ci(jenkins): add defaultPipelineProperties call

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,8 @@ library(
     ])
 )
 
+properties(defaultPipelineProperties())
+
 dt3_pipeline(
     repoName: 'carbonio-tasks-ce',
     projectType: 'CE',

--- a/app/docs/schema.graphql
+++ b/app/docs/schema.graphql
@@ -3,27 +3,27 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 type Query {
+  "Returns service metadata: name, version and flavour."
+  getServiceInfo: ServiceInfo
+  "Returns a single task by its ID for the authenticated user."
+  getTask(
+  taskId: ID): Task
   "Returns all non-trashed tasks for the authenticated user, optionally filtered."
   findTasks(
   status: Status
   priority: Priority): [Task]
-  "Returns a single task by its ID for the authenticated user."
-  getTask(
-  taskId: ID): Task
-  "Returns service metadata: name, version and flavour."
-  getServiceInfo: ServiceInfo
 }
 
 type Mutation {
-  "Moves a task to the TRASH status, making it invisible to normal queries."
-  trashTask(
-  taskId: ID): ID
-  "Updates an existing task. Only fields present in the input are modified."
-  updateTask(
-  updateTask: UpdateTaskInput): Task
   "Creates a new task for the authenticated user."
   createTask(
   newTask: NewTaskInput): Task
+  "Updates an existing task. Only fields present in the input are modified."
+  updateTask(
+  updateTask: UpdateTaskInput): Task
+  "Moves a task to the TRASH status, making it invisible to normal queries."
+  trashTask(
+  taskId: ID): ID
 }
 
 type ServiceInfo {


### PR DESCRIPTION
Add missing properties(defaultPipelineProperties()) call before dt3_pipeline block, required by Zextras Jenkins shared library standards.