### PR TITLE
fix(deps): add explicit service-discover-base dependency

### DIFF
--- a/app/docs/schema.graphql
+++ b/app/docs/schema.graphql
@@ -3,27 +3,27 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 type Query {
-  "Returns service metadata: name, version and flavour."
-  getServiceInfo: ServiceInfo
-  "Returns a single task by its ID for the authenticated user."
-  getTask(
-  taskId: ID): Task
   "Returns all non-trashed tasks for the authenticated user, optionally filtered."
   findTasks(
   status: Status
   priority: Priority): [Task]
+  "Returns a single task by its ID for the authenticated user."
+  getTask(
+  taskId: ID): Task
+  "Returns service metadata: name, version and flavour."
+  getServiceInfo: ServiceInfo
 }
 
 type Mutation {
   "Creates a new task for the authenticated user."
   createTask(
   newTask: NewTaskInput): Task
-  "Updates an existing task. Only fields present in the input are modified."
-  updateTask(
-  updateTask: UpdateTaskInput): Task
   "Moves a task to the TRASH status, making it invisible to normal queries."
   trashTask(
   taskId: ID): ID
+  "Updates an existing task. Only fields present in the input are modified."
+  updateTask(
+  updateTask: UpdateTaskInput): Task
 }
 
 type ServiceInfo {

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -14,6 +14,7 @@ priority="optional"
 url="https://www.zextras.com/"
 depends=(
   "service-discover"
+  "service-discover-base"
   "pending-setups"
 )
 source=(


### PR DESCRIPTION
## Summary

Fixes CO-3711: sidecar services fail when `/usr/bin/service-discover-wrapper.sh` is missing.

## Root Cause

`service-discover-wrapper.sh` is provided by `service-discover-base`. This package was only a transitive dependency, so if it became stale or mismatched (e.g. installed from a devel repo with a NEVRA no longer available), `dnf reinstall` could not restore the missing file.

## Fix

Add `service-discover-base` as an explicit dependency so the package manager enforces it at install/upgrade time.

## References

- [CO-3711](https://zextras.atlassian.net/browse/CO-3711)

[CO-3711]: https://zextras.atlassian.net/browse/CO-3711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ