### PR TITLE
fix(reuse): project-owned REUSE.toml

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -22,6 +22,12 @@ SPDX-FileCopyrightText = "2026 Zextras"
 SPDX-License-Identifier = "AGPL-3.0-only"
 
 [[annotations]]
+path = "COPYING"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2023 Zextras"
+SPDX-License-Identifier = "AGPL-3.0-only"
+
+[[annotations]]
 path = ".github/**"
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2026 Zextras"
@@ -46,13 +52,19 @@ SPDX-FileCopyrightText = "2025 Zextras"
 SPDX-License-Identifier = "AGPL-3.0-only"
 
 [[annotations]]
+path = ["app/src/main/resources/db/migration/**", "app/src/main/resources/META-INF/carbonio-migrations.list"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2023 Zextras"
+SPDX-License-Identifier = "AGPL-3.0-only"
+
+[[annotations]]
 path = "yap.json"
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2023 Zextras s.r.l"
 SPDX-License-Identifier = "AGPL-3.0-only"
 
 [[annotations]]
-path = "**"
+path = ["mvnw", "mvnw.cmd"]
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2026 Zextras <https://www.zextras.com>"
-SPDX-License-Identifier = "AGPL-3.0-only"
+SPDX-FileCopyrightText = "2001-2024 The Apache Software Foundation <https://www.apache.org>"
+SPDX-License-Identifier = "Apache-2.0"

--- a/app/docs/configs.md
+++ b/app/docs/configs.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 # Default Configuration
 
 ## Networking Config

--- a/app/docs/configs.md
+++ b/app/docs/configs.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 # Default Configuration
 
 ## Networking Config

--- a/app/docs/schema.graphql
+++ b/app/docs/schema.graphql
@@ -1,29 +1,25 @@
-# SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
-#
-# SPDX-License-Identifier: AGPL-3.0-only
-
 type Query {
-  "Returns service metadata: name, version and flavour."
-  getServiceInfo: ServiceInfo
-  "Returns a single task by its ID for the authenticated user."
-  getTask(
-  taskId: ID): Task
   "Returns all non-trashed tasks for the authenticated user, optionally filtered."
   findTasks(
   status: Status
   priority: Priority): [Task]
+  "Returns a single task by its ID for the authenticated user."
+  getTask(
+  taskId: ID): Task
+  "Returns service metadata: name, version and flavour."
+  getServiceInfo: ServiceInfo
 }
 
 type Mutation {
-  "Creates a new task for the authenticated user."
-  createTask(
-  newTask: NewTaskInput): Task
   "Updates an existing task. Only fields present in the input are modified."
   updateTask(
   updateTask: UpdateTaskInput): Task
   "Moves a task to the TRASH status, making it invisible to normal queries."
   trashTask(
   taskId: ID): ID
+  "Creates a new task for the authenticated user."
+  createTask(
+  newTask: NewTaskInput): Task
 }
 
 type ServiceInfo {

--- a/app/docs/schema.graphql
+++ b/app/docs/schema.graphql
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
 type Query {
   "Returns service metadata: name, version and flavour."
   getServiceInfo: ServiceInfo


### PR DESCRIPTION
Devel reuse lint (verify mode) was failing after the dt3-pipeline merge. This makes REUSE.toml project-owned: removes the lib's path=** catch-all, migrates+removes legacy .reuse/dep5, completes LICENSES/, and covers excluded/pinned paths (Flyway migrations, package/) via annotations WITHOUT modifying them. reuse lint (fsfe/reuse:5.0.2) passes locally.

Notes:
- No legacy .reuse/dep5 existed in this repo (nothing to migrate).
- mvnw / mvnw.cmd are Apache Software Foundation files and are now correctly annotated as Apache-2.0 (the catch-all had mislabeled them AGPL-3.0-only); added LICENSES/Apache-2.0.txt.
- Flyway migrations under app/src/main/resources/db/migration and everything under package/ are byte-identical (covered via REUSE.toml annotations, not edited).

🤖 Generated with [Claude Code](https://claude.com/claude-code)