### PR TITLE
feat(migration): V2 migrate dotted DB-credential KV keys to the slash path

### DIFF
--- a/THIRDPARTIES
+++ b/THIRDPARTIES
@@ -1,8 +1,8 @@
 AGPL-3.0-only (https://spdx.org/licenses/AGPL-3.0-only.html) applies to:
 
-  Carbonio Quarkus Extensions - Bootstrap Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-bootstrap:1.9.2-1)
-  Carbonio Quarkus Extensions - Database Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-database:1.9.2-1)
-  Carbonio Quarkus Extensions - GraphQL Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-graphql:1.9.2-1)
+  Carbonio Quarkus Extensions - Bootstrap Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-bootstrap:1.10.1-1)
+  Carbonio Quarkus Extensions - Database Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-database:1.10.1-1)
+  Carbonio Quarkus Extensions - GraphQL Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-graphql:1.10.1-1)
   Carbonio User Management - gRPC SDK (com.zextras.carbonio.user-management:carbonio-user-management-grpc-sdk:1.0.3-dev.21.79fc3fa2)
 
 Apache-2.0 (https://spdx.org/licenses/Apache-2.0.html) applies to:

--- a/app/docs/configs.md
+++ b/app/docs/configs.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 # Default Configuration
 
 ## Networking Config

--- a/app/docs/schema.graphql
+++ b/app/docs/schema.graphql
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
-#
-# SPDX-License-Identifier: AGPL-3.0-only
-
 type Query {
   "Returns all non-trashed tasks for the authenticated user, optionally filtered."
   findTasks(

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -51,17 +51,17 @@ SPDX-License-Identifier: AGPL-3.0-only
     <dependency>
       <groupId>com.zextras.carbonio.quarkus</groupId>
       <artifactId>carbonio-quarkus-extensions-bootstrap</artifactId>
-      <version>1.9.2-1</version>
+      <version>1.10.1-1</version>
     </dependency>
     <dependency>
       <groupId>com.zextras.carbonio.quarkus</groupId>
       <artifactId>carbonio-quarkus-extensions-database</artifactId>
-      <version>1.9.2-1</version>
+      <version>1.10.1-1</version>
     </dependency>
     <dependency>
       <groupId>com.zextras.carbonio.quarkus</groupId>
       <artifactId>carbonio-quarkus-extensions-graphql</artifactId>
-      <version>1.9.2-1</version>
+      <version>1.10.1-1</version>
     </dependency>
 
     <!-- Database: Panache ORM + Flyway -->
@@ -99,7 +99,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <dependency>
       <groupId>com.zextras.carbonio.quarkus</groupId>
       <artifactId>carbonio-quarkus-extensions-bootstrap</artifactId>
-      <version>1.9.2-1</version>
+      <version>1.10.1-1</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/app/src/main/java/com/zextras/carbonio/tasks/config/migration/V2__MigrateDottedDbCredentialsToSlash.java
+++ b/app/src/main/java/com/zextras/carbonio/tasks/config/migration/V2__MigrateDottedDbCredentialsToSlash.java
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.tasks.config.migration;
+
+import com.zextras.carbonio.quarkus.extensions.bootstrap.setup.migration.ConfigMigration;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+/**
+ * Migrates the DB-credential KV keys that early carbonio-tasks-db releases wrote in DOTTED form
+ * ({@code carbonio-tasks/database.credentials.db-*}) to the documented nested SLASH path
+ * ({@code carbonio-tasks/database/credentials/db-*}).
+ *
+ * <p>The documented contract (configs.md), {@link V1__RenameDbCredentials}, and the fixed
+ * carbonio-tasks-db bootstrap all use the slash path. The carbonio-quarkus-extensions reader maps
+ * that path to the property {@code application-config.database.credentials.db-name} via
+ * {@code replace('/','.')}, so the dotted key happens to resolve to the same property at runtime —
+ * but it does not match the documented layout, and a path-based (non-extension) KV consumer reading
+ * {@code carbonio-tasks/database/credentials/db-name} would miss it.
+ *
+ * <p>This migration only affects instances that actually carry the dotted keys, i.e. fresh installs
+ * created by a tasks-db release that wrote them. Upgraded instances already have the slash path (via
+ * {@link V1__RenameDbCredentials}) and future fresh installs get it directly (fixed bootstrap), so
+ * here the dotted old key is absent and the entry is skipped. Value-preserving (no password
+ * regeneration): the runner reads the existing dotted value, writes it to the slash key, then
+ * deletes the dotted key. Idempotent: a re-run finds no dotted key and is a no-op.
+ */
+public class V2__MigrateDottedDbCredentialsToSlash extends ConfigMigration {
+
+  private static final String SVC = "carbonio-tasks";
+
+  @Override
+  protected Map<String, BiConsumer<String, String>> networkingMigrations() {
+    return Map.of();
+  }
+
+  @Override
+  protected Map<String, BiConsumer<String, String>> applicationMigrations() {
+    return Map.of(
+        SVC + "/database.credentials.db-name",
+        (k, v) -> applicationConfig.set(SVC + "/database/credentials/db-name", v),
+        SVC + "/database.credentials.db-username",
+        (k, v) -> applicationConfig.set(SVC + "/database/credentials/db-username", v),
+        SVC + "/database.credentials.db-password",
+        (k, v) -> applicationConfig.set(SVC + "/database/credentials/db-password", v));
+  }
+}

--- a/app/src/main/resources/META-INF/carbonio-migrations.list
+++ b/app/src/main/resources/META-INF/carbonio-migrations.list
@@ -1,1 +1,2 @@
 com.zextras.carbonio.tasks.config.migration.V1__RenameDbCredentials
+com.zextras.carbonio.tasks.config.migration.V2__MigrateDottedDbCredentialsToSlash

--- a/app/src/test/java/com/zextras/carbonio/tasks/StackTestResource.java
+++ b/app/src/test/java/com/zextras/carbonio/tasks/StackTestResource.java
@@ -233,12 +233,13 @@ public class StackTestResource implements QuarkusTestResourceLifecycleManager {
     HttpClient client = HttpClient.newHttpClient();
 
     // DB credentials for tasks-ce.
-    // CarbonioBootstrapFactory.loadConsulKV() issues a SINGLE recursive GET:
-    //   GET /v1/kv/carbonio-tasks/?recurse
-    // and expects a JSON array of all KV entries. Individual-key stubs never match that
-    // request, so we register one stub that covers the whole prefix and returns all three
-    // credential entries in the Consul recursive-response format.
-    postConsulKvRecursiveStub(client, wireMockAdminUrl, "carbonio-tasks/",
+    // carbonio-quarkus-extensions (>= 1.10.x) issues a SINGLE ROOT recursive GET at boot:
+    //   GET /v1/kv/?recurse   (prefix == "", urlPath ignores the query string)
+    // Consul ACL-filters that root recurse to the keys the token can read; the boot factory then
+    // derives the own-service application-config view from the carbonio-tasks/* subset. So we stub
+    // the ROOT recurse (not the per-prefix one) and return all three credential entries in the
+    // Consul recursive-response format. (Pre-1.10 the factory recursed /v1/kv/carbonio-tasks/.)
+    postConsulKvRecursiveStub(client, wireMockAdminUrl, "",
         new String[][]{
             {"carbonio-tasks/database/credentials/db-name",     DB_NAME},
             {"carbonio-tasks/database/credentials/db-username", DB_USER},


### PR DESCRIPTION
## What
New config migration `V2__MigrateDottedDbCredentialsToSlash` that converts the DB-credential Consul KV keys from the **dotted** form (`carbonio-tasks/database.credentials.db-*`) that early `carbonio-tasks-db` releases wrote on fresh installs, to the documented nested **slash** path (`carbonio-tasks/database/credentials/db-*`).

## Why
`app/docs/configs.md`, `V1__RenameDbCredentials`, and the fixed `carbonio-tasks-db` bootstrap all use the slash path. The extension's `replace('/','.')` normalizes the dotted key to the same property at runtime (so tasks works today), but the dotted layout violates the documented contract and is missed by path-based KV consumers.

## Behaviour
- Value-preserving (no password regeneration).
- The migration runner writes the slash key, then deletes the dotted one; idempotent.
- **No-op** where the dotted key is absent — upgraded instances (already slash via `V1`) and future fresh installs (slash via the fixed bootstrap). It only does work on instances actually carrying dotted keys (fresh-installed with a dotted `tasks-db`).
- Registered in `META-INF/carbonio-migrations.list`.

## Rollout note
`carbonio-tasks` (Advanced) has no migration code of its own — it inherits migrations from the pinned `carbonio-tasks-ce-app` jar (Jandex index, run at `--setup`). So after this releases, bump `carbonio-tasks-ce.version` in the tasks Advanced `pom.xml` (currently `1.1.3-1`) for Advanced to run `V2`.

Companion: `carbonio-tasks-db` branch `fix/db-cred-kv-slash-path` (fixes future fresh installs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
