### PR TITLE
feat: adopt package-scoped KV migrations (extensions 1.11.0-1)

### DIFF
--- a/THIRDPARTIES
+++ b/THIRDPARTIES
@@ -1,8 +1,8 @@
 AGPL-3.0-only (https://spdx.org/licenses/AGPL-3.0-only.html) applies to:
 
-  Carbonio Quarkus Extensions - Bootstrap Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-bootstrap:1.10.1-1)
-  Carbonio Quarkus Extensions - Database Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-database:1.10.1-1)
-  Carbonio Quarkus Extensions - GraphQL Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-graphql:1.10.1-1)
+  Carbonio Quarkus Extensions - Bootstrap Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-bootstrap:1.11.0-1)
+  Carbonio Quarkus Extensions - Database Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-database:1.11.0-1)
+  Carbonio Quarkus Extensions - GraphQL Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-graphql:1.11.0-1)
   Carbonio User Management - gRPC SDK (com.zextras.carbonio.user-management:carbonio-user-management-grpc-sdk:1.0.3-dev.21.79fc3fa2)
 
 Apache-2.0 (https://spdx.org/licenses/Apache-2.0.html) applies to:

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -51,17 +51,17 @@ SPDX-License-Identifier: AGPL-3.0-only
     <dependency>
       <groupId>com.zextras.carbonio.quarkus</groupId>
       <artifactId>carbonio-quarkus-extensions-bootstrap</artifactId>
-      <version>1.10.1-1</version>
+      <version>1.11.0-1</version>
     </dependency>
     <dependency>
       <groupId>com.zextras.carbonio.quarkus</groupId>
       <artifactId>carbonio-quarkus-extensions-database</artifactId>
-      <version>1.10.1-1</version>
+      <version>1.11.0-1</version>
     </dependency>
     <dependency>
       <groupId>com.zextras.carbonio.quarkus</groupId>
       <artifactId>carbonio-quarkus-extensions-graphql</artifactId>
-      <version>1.10.1-1</version>
+      <version>1.11.0-1</version>
     </dependency>
 
     <!-- Database: Panache ORM + Flyway -->
@@ -99,7 +99,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <dependency>
       <groupId>com.zextras.carbonio.quarkus</groupId>
       <artifactId>carbonio-quarkus-extensions-bootstrap</artifactId>
-      <version>1.10.1-1</version>
+      <version>1.11.0-1</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/app/src/main/resources/META-INF/carbonio-migrations.list
+++ b/app/src/main/resources/META-INF/carbonio-migrations.list
@@ -1,2 +1,0 @@
-com.zextras.carbonio.tasks.config.migration.V1__RenameDbCredentials
-com.zextras.carbonio.tasks.config.migration.V2__MigrateDottedDbCredentialsToSlash

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -33,3 +33,7 @@ quarkus.native.additional-build-args=--initialize-at-run-time=org.postgresql.ssp
 quarkus.flyway.baseline-on-migrate=true
 quarkus.flyway.baseline-version=0
 # Note: Flyway PostgreSQL advisory lock is enabled (default). Safe for sequential upgrades.
+
+# Config-KV migrations: scope build-time discovery to CE's own migration package.
+# The extensions build step writes ONLY these FQCNs to META-INF/carbonio-migrations.list.
+quarkus.carbonio-bootstrap.migrations-package=com.zextras.carbonio.tasks.config.migration


### PR DESCRIPTION
## What

Adopt the new package-scoped KV migration mechanism introduced in `carbonio-quarkus-extensions` `1.11.0-1`:

- Set `quarkus.carbonio-bootstrap.migrations-package=com.zextras.carbonio.tasks.config.migration` in `application.properties`, so the extensions build step discovers only CE's own migration classes.
- Delete the redundant, hand-maintained `META-INF/carbonio-migrations.list` — it is now auto-generated at build time from the package filter.
- Bump all three `carbonio-quarkus-extensions` dependencies (`bootstrap`, `database`, `graphql`, plus the `bootstrap` `test-jar`) from `1.10.1-1` to `1.11.0-1`.

## Why

- Keeps CE's config-KV migrations isolated from Advanced's, so building CE never picks up Advanced-only migration classes (and vice versa).
- Single source of truth for the migration list: the classes in the package define it, instead of a separate file that could drift.

## Testing

- `mvn clean package` (via wrapper, Maven 3.9.9 / Java 21): **BUILD SUCCESS**.
- Unit tests pass against the real published `1.11.0-1`: **Tests run: 9, Failures: 0, Errors: 0, Skipped: 0**. (Integration tests remain skipped by the project's default flags, as in normal local builds; CI runs them.)
- `--setup` smoke test loads exactly CE's two migrations: `Config migration: 2 migration(s) found.` (V1__RenameDbCredentials, V2__MigrateDottedDbCredentialsToSlash), then errors on the intentionally-unreachable Consul — expected.
- The auto-generated `META-INF/carbonio-migrations.list` (in the fast-jar's `generated-bytecode.jar`) contains **only** the two CE-package classes:
  ```
  com.zextras.carbonio.tasks.config.migration.V1__RenameDbCredentials
  com.zextras.carbonio.tasks.config.migration.V2__MigrateDottedDbCredentialsToSlash
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
