### PR TITLE
chore(renovate): pin ubuntu base image to 24.04, block OS major bumps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -30,6 +30,21 @@
       ],
       "matchCurrentValue": "/^dt3-pipeline$/",
       "enabled": false
+    },
+    {
+      "description": "Keep ubuntu Docker base images on the 24.04 (noble) LTS line; do not auto-bump the OS major (the runtime image runs the native binary directly against glibc). Bump manually when there is a concrete driver.",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "ubuntu",
+        "docker.io/library/ubuntu"
+      ],
+      "matchCurrentValue": "/^(noble|24\\.04)/",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Why

Renovate proposed a major bump of the ubuntu Docker base image (noble -> 26.x). That bump was closed as unwanted: this service ships a native (GraalVM) binary in the runtime image, linked directly against the base image's glibc, and there is no concrete driver today to move off the 24.04 (noble) LTS line. An unreviewed OS major jump risks a glibc/ABI mismatch for the native binary.

## What

Adds a local Renovate `packageRules` entry (`.github/renovate.json`) that:
- Matches the `ubuntu` / `docker.io/library/ubuntu` docker images currently pinned to `noble` or `24.04`.
- Disables (`enabled: false`) only `major` update types for those packages.
- Leaves digest and patch refreshes on the 24.04 line untouched, so security/patch updates within noble still flow normally.

When there's a concrete reason to move to a newer Ubuntu LTS, this rule should be removed/updated manually alongside that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)