### PR TITLE
fix(auth): return 403 instead of 401 for disabled feature, inactive, or guest user

### DIFF
--- a/app/src/main/java/com/zextras/carbonio/tasks/auth/AuthenticationFilter.java
+++ b/app/src/main/java/com/zextras/carbonio/tasks/auth/AuthenticationFilter.java
@@ -58,8 +58,9 @@ public class AuthenticationFilter {
 
   /**
    * Core auth logic. Called for every request matching {@code /graphql} or {@code /graphql/}.
-   * Sets {@link Context#REQUESTER_ID} in the routing context on success, or ends the response with
-   * HTTP 401 on failure.
+   * Sets {@link Context#REQUESTER_ID} in the routing context on success. Ends the response with
+   * HTTP 401 if the request is not authenticated (missing/invalid cookie), or HTTP 403 if the
+   * user is authenticated but not entitled to use Tasks (guest, inactive, or feature disabled).
    */
   void filter(RoutingContext ctx) {
     io.vertx.core.http.Cookie zmCookie = ctx.request().getCookie(Config.ACCEPTED_COOKIE_TYPE);
@@ -79,20 +80,20 @@ public class AuthenticationFilter {
       UserMyselfProto userMyself = grpcResponse.getUser();
 
       if (userMyself.getInfo().getType() == UserTypeProto.GUEST) {
-        logger.error("The request is unauthorized: the user is a guest");
-        ctx.response().setStatusCode(401).end();
+        logger.error("The request is forbidden: the user is a guest");
+        ctx.response().setStatusCode(403).end();
         return;
       }
 
       if (!userMyself.getInfo().getStatus().equalsIgnoreCase("active")) {
-        logger.error("The request is unauthorized: the user is not active");
-        ctx.response().setStatusCode(401).end();
+        logger.error("The request is forbidden: the user is not active");
+        ctx.response().setStatusCode(403).end();
         return;
       }
 
       if (!userMyself.getFeaturesList().contains("carbonioFeatureTasksEnabled")) {
-        logger.error("The request is unauthorized: the user does not have Tasks feature enabled");
-        ctx.response().setStatusCode(401).end();
+        logger.error("The request is forbidden: the user does not have Tasks feature enabled");
+        ctx.response().setStatusCode(403).end();
         return;
       }
 

--- a/app/src/test/java/com/zextras/carbonio/tasks/auth/AuthenticationFilterTest.java
+++ b/app/src/test/java/com/zextras/carbonio/tasks/auth/AuthenticationFilterTest.java
@@ -133,7 +133,7 @@ class AuthenticationFilterTest {
   }
 
   @Test
-  void givenAGuestUserTheFilterShouldRespondWith401() {
+  void givenAGuestUserTheFilterShouldRespondWith403() {
     Cookie zmCookie = Mockito.mock(Cookie.class);
     Mockito.when(zmCookie.getValue()).thenReturn("guest-token");
 
@@ -156,13 +156,13 @@ class AuthenticationFilterTest {
 
     filter.filter(ctx);
 
-    Mockito.verify(ctx.response()).setStatusCode(401);
+    Mockito.verify(ctx.response()).setStatusCode(403);
     Mockito.verify(ctx.response()).end();
     Mockito.verify(ctx, Mockito.never()).next();
   }
 
   @Test
-  void givenAnInactiveUserTheFilterShouldRespondWith401() {
+  void givenAnInactiveUserTheFilterShouldRespondWith403() {
     Cookie zmCookie = Mockito.mock(Cookie.class);
     Mockito.when(zmCookie.getValue()).thenReturn("inactive-token");
 
@@ -185,13 +185,13 @@ class AuthenticationFilterTest {
 
     filter.filter(ctx);
 
-    Mockito.verify(ctx.response()).setStatusCode(401);
+    Mockito.verify(ctx.response()).setStatusCode(403);
     Mockito.verify(ctx.response()).end();
     Mockito.verify(ctx, Mockito.never()).next();
   }
 
   @Test
-  void givenAUserWithoutTasksFeatureTheFilterShouldRespondWith401() {
+  void givenAUserWithoutTasksFeatureTheFilterShouldRespondWith403() {
     Cookie zmCookie = Mockito.mock(Cookie.class);
     Mockito.when(zmCookie.getValue()).thenReturn("no-tasks-token");
 
@@ -214,7 +214,7 @@ class AuthenticationFilterTest {
 
     filter.filter(ctx);
 
-    Mockito.verify(ctx.response()).setStatusCode(401);
+    Mockito.verify(ctx.response()).setStatusCode(403);
     Mockito.verify(ctx.response()).end();
     Mockito.verify(ctx, Mockito.never()).next();
   }


### PR DESCRIPTION
AuthenticationFilter returned HTTP 401 when a user was a guest, inactive, or missing the Tasks feature flag, masking these authenticated-but-not-entitled cases as generic authentication failures (matching complaints in CO-3482 about misleading 401s hiding a disabled feature flag).

Missing/invalid ZM_AUTH_TOKEN still return 401 (genuine auth failure); guest user, inactive user, and disabled carbonioFeatureTasksEnabled now return 403 with a clearer log message, mirroring the fix already applied to carbonio-ws-collaboration.

ref: CO-3482
