### PR TITLE
fix(deps): bump extensions to 1.12.1-1, drop manual bundle flag, add native regression guard

### DIFF
--- a/THIRDPARTIES
+++ b/THIRDPARTIES
@@ -1,8 +1,8 @@
 AGPL-3.0-only (https://spdx.org/licenses/AGPL-3.0-only.html) applies to:
 
-  Carbonio Quarkus Extensions - Bootstrap Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-bootstrap:1.11.2-1)
-  Carbonio Quarkus Extensions - Database Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-database:1.11.2-1)
-  Carbonio Quarkus Extensions - GraphQL Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-graphql:1.11.2-1)
+  Carbonio Quarkus Extensions - Bootstrap Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-bootstrap:1.12.1-1)
+  Carbonio Quarkus Extensions - Database Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-database:1.12.1-1)
+  Carbonio Quarkus Extensions - GraphQL Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-graphql:1.12.1-1)
   Carbonio User Management - REST SDK (com.zextras.carbonio.user-management:carbonio-user-management-rest-sdk:1.3.0-1)
 
 Apache-2.0 (https://spdx.org/licenses/Apache-2.0.html) applies to:

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -51,17 +51,17 @@ SPDX-License-Identifier: AGPL-3.0-only
     <dependency>
       <groupId>com.zextras.carbonio.quarkus</groupId>
       <artifactId>carbonio-quarkus-extensions-bootstrap</artifactId>
-      <version>1.11.2-1</version>
+      <version>1.12.1-1</version>
     </dependency>
     <dependency>
       <groupId>com.zextras.carbonio.quarkus</groupId>
       <artifactId>carbonio-quarkus-extensions-database</artifactId>
-      <version>1.11.2-1</version>
+      <version>1.12.1-1</version>
     </dependency>
     <dependency>
       <groupId>com.zextras.carbonio.quarkus</groupId>
       <artifactId>carbonio-quarkus-extensions-graphql</artifactId>
-      <version>1.11.2-1</version>
+      <version>1.12.1-1</version>
     </dependency>
 
     <!-- Database: Panache ORM + Flyway -->
@@ -97,7 +97,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <dependency>
       <groupId>com.zextras.carbonio.quarkus</groupId>
       <artifactId>carbonio-quarkus-extensions-bootstrap</artifactId>
-      <version>1.11.2-1</version>
+      <version>1.12.1-1</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -16,9 +16,10 @@ networking-config.carbonio.user-management.host=127.78.0.16
 networking-config.carbonio.user-management.port=20001
 
 # Native build: initialize PostgreSQL SSPI at run time (not build time)
-# Also register graphql-java's i18n.Scalars resource bundle, otherwise enum validation
-# errors throw MissingResourceException (HTTP 500) in the native image.
-quarkus.native.additional-build-args=--initialize-at-run-time=org.postgresql.sspi.SSPIClient,-H:IncludeResourceBundles=i18n.Scalars
+# graphql-java's i18n.Scalars/i18n.Execution resource bundles are registered for native images
+# by carbonio-quarkus-extensions-graphql's own build step (NativeImageResourceBundleBuildItem,
+# since 1.12.1-1) - do NOT re-add -H:IncludeResourceBundles=i18n.Scalars here.
+quarkus.native.additional-build-args=--initialize-at-run-time=org.postgresql.sspi.SSPIClient
 
 # Test profile: containers are managed by ConsulTestResource; disable Quarkus DevServices
 %test.quarkus.devservices.enabled=false

--- a/app/src/test/java/com/zextras/carbonio/tasks/StackTestResource.java
+++ b/app/src/test/java/com/zextras/carbonio/tasks/StackTestResource.java
@@ -195,7 +195,17 @@ public class StackTestResource implements QuarkusTestResourceLifecycleManager {
             + "\"displayName\":\"Test User\","
             + "\"status\":\"active\","
             + "\"isGlobalAdmin\":false,"
+            // Both booleans, because mailbox really returns both and they are NOT synonyms:
+            // isExternal is derived from zimbraMailTransport not matching the server named by
+            // zimbraMailHost (foreign/relayed MTA routing), while isExternalVirtualAccount is the
+            // LDAP zimbraIsExternalVirtualAccount flag marking a guest / external-share account.
+            // user-management's UserService#mapAccountInfoToUserMyself classifies GUEST-vs-INTERNAL
+            // off isExternalVirtualAccount() only. A normal internal account is false for both.
+            // Omitting the field let the mailbox-sdk AccountInfo record silently default it to
+            // false, which happened to give the right answer here only because this suite never
+            // exercises a guest account.
             + "\"isExternal\":false,"
+            + "\"isExternalVirtualAccount\":false,"
             + "\"locale\":\"en_US\","
             + "\"features\":{\"carbonioFeatureTasksEnabled\":true},"
             + "\"capabilities\":{},"

--- a/app/src/test/java/com/zextras/carbonio/tasks/graphql/TasksGraphQLApiIT.java
+++ b/app/src/test/java/com/zextras/carbonio/tasks/graphql/TasksGraphQLApiIT.java
@@ -299,6 +299,79 @@ class TasksGraphQLApiIT {
             Matchers.containsString("Could not find task with id " + unknownId));
   }
 
+  // ─────────────── native resource-bundle regression guard (i18n.Scalars) ───────────────
+  //
+  // graphql-java loads a ResourceBundle named "i18n.Scalars" to build the human-readable
+  // messages for enum- and built-in-scalar-coercion failures (see
+  // graphql.scalar.CoercingUtil#i18nMsg, used by graphql.schema.GraphQLEnumType and by the
+  // Graphql*Coercing classes for Int/Float/Boolean/String/ID). Under GraalVM native-image,
+  // ResourceBundle.getBundle(...) throws MissingResourceException unless the bundle is
+  // explicitly registered at build time. quarkus-smallrye-graphql upstream only registers
+  // i18n.Validation and i18n.Parsing, never i18n.Scalars, so WITHOUT the explicit
+  // "-H:IncludeResourceBundles=i18n.Scalars" native build arg (see application.properties,
+  // quarkus.native.additional-build-args) any invalid enum literal or invalid built-in-scalar
+  // literal in a request crashes with an unhandled MissingResourceException, surfacing to the
+  // client as HTTP 500 with "data": null and no "errors" array, instead of a normal HTTP 200
+  // GraphQL validation error.
+  //
+  // The two tests below are the ONLY regression coverage for that registration. Commit 8700920
+  // added the native build arg fix, but in the very same commit changed
+  // findTasksShouldFilterByStatus to stop sending the invalid literal "CLOSED" (replacing it
+  // with the valid "COMPLETE"), which silently deleted the only test exercising the code path
+  // the fix protects. Do not repeat that mistake:
+  //  - Do NOT "simplify" or "fix" these tests by switching to a valid Status value or a
+  //    correctly-typed argument. An invalid literal is the entire point: it is what forces
+  //    graphql-java down the i18n.Scalars-dependent coercion path.
+  //  - These tests only prove the registration is intact when the suite runs against the
+  //    NATIVE binary. In JVM mode, ResourceBundle.getBundle("i18n.Scalars", ...) resolves
+  //    normally from i18n/Scalars.properties on the classpath regardless of the native build
+  //    arg, so a green result here in JVM mode does NOT prove the native registration works —
+  //    it only proves graphql-java's ordinary (non-native) behavior, which was never broken.
+  //    As of this writing, CI does not yet run the IT suite against the native binary
+  //    (jenkins-lib-common PR #150 adds that, still open).
+
+  /**
+   * Sends the exact invalid enum literal ({@code Status(CLOSED)}) that {@code
+   * findTasksShouldFilterByStatus} used to send before commit 8700920 replaced it with a valid
+   * one. {@code Status} only defines {@code OPEN}, {@code COMPLETE} and {@code TRASH}, so {@code
+   * CLOSED} forces graphql-java's {@code GraphQLEnumType} coercion to fail and build its error
+   * message from the {@code i18n.Scalars} resource bundle.
+   *
+   * <p>See the section comment above: this must keep sending an invalid literal, and it is only
+   * a real guard against the native resource-bundle registration when run against the native
+   * binary.
+   */
+  @Test
+  void findTasksWithInvalidEnumLiteralShouldReturnGraphQLErrorNotServerError() {
+    postAuth("{\"query\": \"{ findTasks(status: CLOSED) { id title status } }\"}")
+        // Explicitly NOT a 500: an unregistered i18n.Scalars bundle under native-image would
+        // throw MissingResourceException and surface here as HTTP 500 with a null "data".
+        .statusCode(200)
+        .body("errors", Matchers.not(Matchers.empty()))
+        .body("errors[0].message", Matchers.containsString("Status"));
+  }
+
+  /**
+   * Sends a Boolean literal ({@code true}) for {@code taskId}, which the schema types as the
+   * built-in {@code ID} scalar. {@code ID} only accepts {@code StringValue}/{@code IntValue}
+   * literals, so this forces {@code GraphqlIDCoercing} to fail and build its error message from
+   * the same {@code i18n.Scalars} bundle as the enum case above, via a different coercion path
+   * (built-in scalar rather than enum).
+   *
+   * <p>See the section comment above: this must keep sending a wrongly-typed literal, and it is
+   * only a real guard against the native resource-bundle registration when run against the
+   * native binary.
+   */
+  @Test
+  void getTaskWithWrongLiteralTypeShouldReturnGraphQLErrorNotServerError() {
+    postAuth("{\"query\": \"{ getTask(taskId: true) { id } }\"}")
+        // Explicitly NOT a 500: an unregistered i18n.Scalars bundle under native-image would
+        // throw MissingResourceException and surface here as HTTP 500 with a null "data".
+        .statusCode(200)
+        .body("errors", Matchers.not(Matchers.empty()))
+        .body("errors[0].message", Matchers.containsString("ID"));
+  }
+
   // ─────────────── helpers ───────────────
 
   private ValidatableResponse postAuth(String jsonBody) {


### PR DESCRIPTION
Three coupled changes.

**1. Regression guard restored.** Commit `8700920` fixed the native `i18n.Scalars` bundle problem by adding `-H:IncludeResourceBundles=i18n.Scalars` — but the same commit changed `findTasksShouldFilterByStatus` from the invalid literal `CLOSED` to a valid `Status`, **deleting the only test that exercised the failing path**. Nothing would have caught the registration being dropped. That is exactly how the Advanced repo drifted: it never had the flag at all.

Two tests added to `TasksGraphQLApiIT`:
- `findTasksWithInvalidEnumLiteralShouldReturnGraphQLErrorNotServerError` — `findTasks(status: CLOSED)`
- `getTaskWithWrongLiteralTypeShouldReturnGraphQLErrorNotServerError` — `getTask(taskId: true)`, a Boolean literal against the `ID` scalar

Both assert HTTP 200 + non-empty `errors[]`. The problem is **not** enum-specific: `CoercingUtil.i18nMsg` is reached from `GraphQLEnumType` and from `Graphql{Int,ID,Boolean,String,Float}Coercing`, so any built-in-scalar coercion failure is affected. Assertions are on the type names graphql-java substitutes into its own template, not on wording that could drift.

**2. extensions bumped to 1.12.1-1**, which registers `i18n.Scalars` and `i18n.Execution` via a `NativeImageResourceBundleBuildItem` (carbonio-quarkus-extensions#91).

**3. Manual flag removed** — the registration now has a single owner in the extension. `additional-build-args` is single-valued and never merges, so a per-consumer flag is exactly the mechanism that produced the CE/Advanced drift.

**Verification, against the native binary — JVM-green proves nothing here** (the classpath resolves `i18n/Scalars.properties` regardless of the build arg):
- flag present, native runner: 22/22 ITs green, console confirms `Executing ".../carbonio-tasks-ce-app-1.4.0-1-runner"`, not `java -jar`
- flag removed, full native rebuild, **before** the extensions bump: `Tests run: 22, Failures: 2` — exactly the two new tests, both `Expected status code <200> but was <500>`, runner log `java.util.MissingResourceException: Can't find bundle for base name i18n.Scalars, locale en_US`, from both the enum and `ID` paths
- flag removed, **on extensions 1.12.1-1**: 22/22 green again, and `META-INF/native-image/resource-config.json` in the runner jar lists `i18n.Scalars` and `i18n.Execution`

`THIRDPARTIES` updated in the same commit as the bump.

Caveat: these guards only bite when CI runs ITs against the native binary — jenkins-lib-common#150, still open. Today's `nativeBuild` stage runs `-DskipTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012aQVjJLkBymdUS3F6HMe4t