### PR TITLE
chore: bump carbonio-quarkus-extensions to 1.13.0-1

### DIFF
--- a/THIRDPARTIES
+++ b/THIRDPARTIES
@@ -3,9 +3,9 @@ List of third-party dependencies grouped by their license type.
 
     AGPL-3.0-only:
 
-        * Carbonio Quarkus Extensions - Bootstrap Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-bootstrap:1.12.1-1 - no url defined)
-        * Carbonio Quarkus Extensions - Database Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-database:1.12.1-1 - no url defined)
-        * Carbonio Quarkus Extensions - GraphQL Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-graphql:1.12.1-1 - no url defined)
+        * Carbonio Quarkus Extensions - Bootstrap Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-bootstrap:1.13.0-1 - no url defined)
+        * Carbonio Quarkus Extensions - Database Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-database:1.13.0-1 - no url defined)
+        * Carbonio Quarkus Extensions - GraphQL Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-graphql:1.13.0-1 - no url defined)
         * Carbonio User Management - REST SDK (com.zextras.carbonio.user-management:carbonio-user-management-rest-sdk:1.3.0-1 - no url defined)
 
     Apache 2.0:

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -32,6 +32,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <properties>
     <quarkus.version>3.37.2</quarkus.version>
     <assertj.version>3.27.7</assertj.version>
+    <carbonio-quarkus-extensions.version>1.13.0-1</carbonio-quarkus-extensions.version>
   </properties>
 
   <dependencyManagement>
@@ -51,17 +52,17 @@ SPDX-License-Identifier: AGPL-3.0-only
     <dependency>
       <groupId>com.zextras.carbonio.quarkus</groupId>
       <artifactId>carbonio-quarkus-extensions-bootstrap</artifactId>
-      <version>1.12.1-1</version>
+      <version>${carbonio-quarkus-extensions.version}</version>
     </dependency>
     <dependency>
       <groupId>com.zextras.carbonio.quarkus</groupId>
       <artifactId>carbonio-quarkus-extensions-database</artifactId>
-      <version>1.12.1-1</version>
+      <version>${carbonio-quarkus-extensions.version}</version>
     </dependency>
     <dependency>
       <groupId>com.zextras.carbonio.quarkus</groupId>
       <artifactId>carbonio-quarkus-extensions-graphql</artifactId>
-      <version>1.12.1-1</version>
+      <version>${carbonio-quarkus-extensions.version}</version>
     </dependency>
 
     <!-- Database: Panache ORM + Flyway -->
@@ -97,7 +98,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <dependency>
       <groupId>com.zextras.carbonio.quarkus</groupId>
       <artifactId>carbonio-quarkus-extensions-bootstrap</artifactId>
-      <version>1.12.1-1</version>
+      <version>${carbonio-quarkus-extensions.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
Bumps `carbonio-quarkus-extensions` from `1.12.1-1` to `1.13.0-1`.

- Consolidated the four inline extension versions into a single `carbonio-quarkus-extensions.version` property (in `app/pom.xml`) and bumped it — consistent with the other consumers.
- `THIRDPARTIES` regenerated via pre-commit.
- `mvn compile` green against 1.13.0-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)