### PR TITLE
test: abstract @QuarkusIntegrationTest base so new ITs share one launch

### DIFF
--- a/app/src/test/java/com/zextras/carbonio/tasks/graphql/AbstractTasksIT.java
+++ b/app/src/test/java/com/zextras/carbonio/tasks/graphql/AbstractTasksIT.java
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.tasks.graphql;
+
+import com.zextras.carbonio.tasks.StackTestResource;
+import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+@WithTestResource(StackTestResource.class)
+abstract class AbstractTasksIT {}

--- a/app/src/test/java/com/zextras/carbonio/tasks/graphql/ServiceInfoApiIT.java
+++ b/app/src/test/java/com/zextras/carbonio/tasks/graphql/ServiceInfoApiIT.java
@@ -6,17 +6,13 @@ package com.zextras.carbonio.tasks.graphql;
 
 import com.zextras.carbonio.tasks.Constants.Tasks;
 import com.zextras.carbonio.tasks.StackTestResource;
-import io.quarkus.test.common.WithTestResource;
-import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 /** Integration test for the {@code getServiceInfo} GraphQL query. */
-@QuarkusIntegrationTest
-@WithTestResource(StackTestResource.class)
-class ServiceInfoApiIT {
+class ServiceInfoApiIT extends AbstractTasksIT {
 
   @Test
   void getServiceInfoShouldReturnCorrectServiceMetadata() {

--- a/app/src/test/java/com/zextras/carbonio/tasks/graphql/TaskAuthIT.java
+++ b/app/src/test/java/com/zextras/carbonio/tasks/graphql/TaskAuthIT.java
@@ -4,9 +4,6 @@
 
 package com.zextras.carbonio.tasks.graphql;
 
-import com.zextras.carbonio.tasks.StackTestResource;
-import io.quarkus.test.common.WithTestResource;
-import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.Test;
@@ -18,9 +15,7 @@ import org.junit.jupiter.api.Test;
  * <p>Uses {@code @QuarkusIntegrationTest} so the app runs as a separate process and connects to the
  * real user-management container over the network.
  */
-@QuarkusIntegrationTest
-@WithTestResource(StackTestResource.class)
-class TaskAuthIT {
+class TaskAuthIT extends AbstractTasksIT {
 
   private static final String ANY_QUERY =
       "{\"query\": \"mutation { createTask(newTask: {title: \\\"t\\\"}) { id } }\"}";

--- a/app/src/test/java/com/zextras/carbonio/tasks/graphql/TasksGraphQLApiIT.java
+++ b/app/src/test/java/com/zextras/carbonio/tasks/graphql/TasksGraphQLApiIT.java
@@ -5,8 +5,6 @@
 package com.zextras.carbonio.tasks.graphql;
 
 import com.zextras.carbonio.tasks.StackTestResource;
-import io.quarkus.test.common.WithTestResource;
-import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.ValidatableResponse;
@@ -22,9 +20,7 @@ import org.junit.jupiter.api.Test;
  * real user-management container over the network. DB cleanup uses direct JDBC since
  * {@code @Inject} is not available in integration test mode.
  */
-@QuarkusIntegrationTest
-@WithTestResource(StackTestResource.class)
-class TasksGraphQLApiIT {
+class TasksGraphQLApiIT extends AbstractTasksIT {
 
   @BeforeEach
   void cleanUp() throws Exception {


### PR DESCRIPTION
## What
Adds a minimal abstract `@QuarkusIntegrationTest` base class carrying `@QuarkusIntegrationTest` + `@WithTestResource(<StackTestResource>)`; the existing IT class(es) now `extends` it and drop their own annotations.

## Why
So any future IT class automatically shares the ONE launched app (by extending the base) instead of declaring its own test-resource — which, if it diverges, forces a full ~7–8 s app relaunch per class. This is a guardrail against reintroducing the per-class-restart cost. Mirrors carbonio-files-ce's `AbstractFilesIT`.

## Verification
Full `mvn clean verify` (UT + IT) green locally; all tests green on Jenkins (JVM **and** native, 0 failures). Where the branch build shows UNSTABLE it is the best-effort **native-image stage** (pre-existing on this line), not test failures.

> ⚠️ Based off the now-merged/removed parent branch, so this PR also carries one pending upstream commit not yet in `devel`: `e290c32 fix(deps): release carbonio-quarkus-extensions 1.13.0-1 bump`. Review merge order / rebase accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
