### PR TITLE
fix(deps): bump carbonio-quarkus-extensions to 1.14.0-1

### DIFF
--- a/THIRDPARTIES
+++ b/THIRDPARTIES
@@ -3,9 +3,9 @@ List of third-party dependencies grouped by their license type.
 
     AGPL-3.0-only:
 
-        * Carbonio Quarkus Extensions - Bootstrap Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-bootstrap:1.13.0-1 - no url defined)
-        * Carbonio Quarkus Extensions - Database Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-database:1.13.0-1 - no url defined)
-        * Carbonio Quarkus Extensions - GraphQL Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-graphql:1.13.0-1 - no url defined)
+        * Carbonio Quarkus Extensions - Bootstrap Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-bootstrap:1.14.0-1 - no url defined)
+        * Carbonio Quarkus Extensions - Database Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-database:1.14.0-1 - no url defined)
+        * Carbonio Quarkus Extensions - GraphQL Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-graphql:1.14.0-1 - no url defined)
         * Carbonio User Management - REST SDK (com.zextras.carbonio.user-management:carbonio-user-management-rest-sdk:1.3.0-1 - no url defined)
 
     Apache 2.0:

--- a/app/docs/configs.md
+++ b/app/docs/configs.md
@@ -24,6 +24,7 @@ Overridable by Consul KV
 | `carbonio-tasks/database/credentials/db-name` | *(not set)* | Crashes; but always set by database bootstrap |
 | `carbonio-tasks/database/credentials/db-password` | *(not set)* | Crashes; but always set by database bootstrap |
 | `carbonio-tasks/database/credentials/db-username` | *(not set)* | Crashes; but always set by database bootstrap |
+| `carbonio-tasks/database/db-pool-foreground-validation` | *(not set)* | 500ms (foreground validation enabled by default) |
 | `carbonio-tasks/database/db-pool-idle-timeout` | *(not set)* | Quarkus default: 5 minutes |
 | `carbonio-tasks/database/db-pool-leak-detection` | *(not set)* | Quarkus default: disabled |
 | `carbonio-tasks/database/db-pool-max-lifetime` | *(not set)* | Quarkus default: no limit |

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -32,7 +32,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <properties>
     <quarkus.version>3.37.2</quarkus.version>
     <assertj.version>3.27.7</assertj.version>
-    <carbonio-quarkus-extensions.version>1.13.0-1</carbonio-quarkus-extensions.version>
+    <carbonio-quarkus-extensions.version>1.14.0-1</carbonio-quarkus-extensions.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Consume the foreground (on-acquire) DB connection validation default from carbonio-quarkus-extensions 1.14.0-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)